### PR TITLE
update `_config.yml`

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: "AB-3"
+title: "Quick Contacts"
 theme: minima
 
 header_pages:
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "se-edu/addressbook-level3"
+repository: "AY2223S2-CS2103T-T11-2/tp"
 github_icon: "images/github-icon.png"
 
 plugins:


### PR DESCRIPTION
This PR updates the `_config.yml` for Jekyll to render `QuickContacts` information instead of the default `AB3`