### PR TITLE
Add `AddMeetingCommand` Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -1,0 +1,103 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.meeting.*;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+/**
+ * Adds a meeting to the address book.
+ */
+public class AddMeetingCommand extends Command {
+    public static final String COMMAND_WORD = "addm";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a meeting to the address book. "
+            + "Parameters: "
+            + PREFIX_MEETING_TITLE + "MEETING "
+            + PREFIX_PERSON + "NAME "
+            + PREFIX_DATE + "DATE\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_MEETING_TITLE + "Meeting with John "
+            + PREFIX_PERSON + "John Doe " + PREFIX_DATE + "2020-10-10";
+
+    public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
+
+    public static final String MESSAGE_DUPLICATE_MEETING = "This meeting already exists in the address book";
+
+    private final Title meetingTitle;
+    private final DateTime dateTime;
+    private final Set<Name> attendeeNames = new HashSet<>();
+    private final Location location;
+    private final Description description;
+
+
+    /**
+     * A more straightforward way to create an AddMeetingCommand to add a {@code Meeting} class.
+     * Used primarily for testing.
+     *
+     * @param meeting to be added
+     */
+    public AddMeetingCommand(Meeting meeting) {
+        requireNonNull(meeting);
+        this.meetingTitle = meeting.getTitle();
+        this.dateTime = meeting.getDateTime();
+        this.attendeeNames.addAll(meeting.getAttendees().stream().map(Person::getName).collect(Collectors.toSet()));
+        this.location = meeting.getLocation();
+        this.description = meeting.getDescription();
+    }
+
+    /**
+     * Creates an AddMeetingCommand to add a {@code Meeting} class with the specified attributes {@code Title}, {@code attendees},
+     * {@code DateTime}, {@code Location}, {@code Description}
+     */
+    public AddMeetingCommand(Title meetingTitle, DateTime dateTime, Set<Name> attendees, Location location,
+                             Description description) {
+        requireAllNonNull(meetingTitle, attendees, dateTime, location, description);
+        this.meetingTitle = meetingTitle;
+        this.dateTime = dateTime;
+        this.attendeeNames.addAll(attendees);
+        this.location = location;
+        this.description = description;
+
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        final Set<Person> attendees = new HashSet<>();
+        for (Name name : attendeeNames) {
+            Person person = model.getPersonByName(name);
+            if (person == null) {
+                throw new CommandException("Person not found: " + name);
+            }
+            attendees.add(person);
+        }
+
+        Meeting meetingToAdd = new Meeting(meetingTitle, dateTime, attendees, location, description);
+
+        if (model.hasMeeting(meetingToAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_MEETING);
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, meetingToAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddMeetingCommand // instanceof handles nulls
+                && meetingTitle.equals(((AddMeetingCommand) other).meetingTitle)
+                && dateTime.equals(((AddMeetingCommand) other).dateTime)
+                && attendeeNames.equals(((AddMeetingCommand) other).attendeeNames)
+                && location.equals(((AddMeetingCommand) other).location)
+                && description.equals(((AddMeetingCommand) other).description));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING_TITLE;
@@ -34,13 +34,13 @@ public class AddMeetingCommand extends Command {
         + "Parameters: "
         + PREFIX_MEETING_TITLE + "MEETING "
         + PREFIX_PERSON + "NAME "
-        + PREFIX_DATE + DATE_FORMAT + " " + TIME_FORMAT + " "
+        + PREFIX_DATETIME + DATE_FORMAT + " " + TIME_FORMAT + " "
         + PREFIX_LOCATION + "LOCATION "
         + PREFIX_DESCRIPTION + "DESCRIPTION "
         + "Example: " + COMMAND_WORD + " "
         + PREFIX_MEETING_TITLE + "Meeting with John "
         + PREFIX_PERSON + "John Doe "
-        + PREFIX_DATE + "02/02/2022 12:00 "
+        + PREFIX_DATETIME + "02/02/2022 12:00 "
         + PREFIX_LOCATION + "Zoom "
         + PREFIX_DESCRIPTION + "Discuss about the project";
 

--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -4,8 +4,12 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING_TITLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON;
+import static seedu.address.model.meeting.DateTime.DATE_FORMAT;
+import static seedu.address.model.meeting.DateTime.TIME_FORMAT;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -30,10 +34,15 @@ public class AddMeetingCommand extends Command {
         + "Parameters: "
         + PREFIX_MEETING_TITLE + "MEETING "
         + PREFIX_PERSON + "NAME "
-        + PREFIX_DATE + "DATE\n"
+        + PREFIX_DATE + DATE_FORMAT + " " + TIME_FORMAT + " "
+        + PREFIX_LOCATION + "LOCATION "
+        + PREFIX_DESCRIPTION + "DESCRIPTION "
         + "Example: " + COMMAND_WORD + " "
         + PREFIX_MEETING_TITLE + "Meeting with John "
-        + PREFIX_PERSON + "John Doe " + PREFIX_DATE + "2020-10-10";
+        + PREFIX_PERSON + "John Doe "
+        + PREFIX_DATE + "02/02/2022 12:00 "
+        + PREFIX_LOCATION + "Zoom "
+        + PREFIX_DESCRIPTION + "Discuss about the project";
 
     public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
 
@@ -44,7 +53,6 @@ public class AddMeetingCommand extends Command {
     private final Set<Name> attendeeNames = new HashSet<>();
     private final Location location;
     private final Description description;
-
 
     /**
      * A more straightforward way to create an AddMeetingCommand to add a {@code Meeting} class.
@@ -73,7 +81,6 @@ public class AddMeetingCommand extends Command {
         this.attendeeNames.addAll(attendees);
         this.location = location;
         this.description = description;
-
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -1,18 +1,25 @@
 package seedu.address.logic.commands;
 
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
-import seedu.address.model.meeting.*;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING_TITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.meeting.DateTime;
+import seedu.address.model.meeting.Description;
+import seedu.address.model.meeting.Location;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.Title;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 
 /**
  * Adds a meeting to the address book.
@@ -20,13 +27,13 @@ import static seedu.address.logic.parser.CliSyntax.*;
 public class AddMeetingCommand extends Command {
     public static final String COMMAND_WORD = "addm";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a meeting to the address book. "
-            + "Parameters: "
-            + PREFIX_MEETING_TITLE + "MEETING "
-            + PREFIX_PERSON + "NAME "
-            + PREFIX_DATE + "DATE\n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_MEETING_TITLE + "Meeting with John "
-            + PREFIX_PERSON + "John Doe " + PREFIX_DATE + "2020-10-10";
+        + "Parameters: "
+        + PREFIX_MEETING_TITLE + "MEETING "
+        + PREFIX_PERSON + "NAME "
+        + PREFIX_DATE + "DATE\n"
+        + "Example: " + COMMAND_WORD + " "
+        + PREFIX_MEETING_TITLE + "Meeting with John "
+        + PREFIX_PERSON + "John Doe " + PREFIX_DATE + "2020-10-10";
 
     public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
 
@@ -55,8 +62,8 @@ public class AddMeetingCommand extends Command {
     }
 
     /**
-     * Creates an AddMeetingCommand to add a {@code Meeting} class with the specified attributes {@code Title}, {@code attendees},
-     * {@code DateTime}, {@code Location}, {@code Description}
+     * Creates an AddMeetingCommand to add a {@code Meeting} class with the specified attributes {@code Title},
+     * {@code attendees}, {@code DateTime}, {@code Location}, {@code Description}
      */
     public AddMeetingCommand(Title meetingTitle, DateTime dateTime, Set<Name> attendees, Location location,
                              Description description) {
@@ -93,11 +100,11 @@ public class AddMeetingCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof AddMeetingCommand // instanceof handles nulls
-                && meetingTitle.equals(((AddMeetingCommand) other).meetingTitle)
-                && dateTime.equals(((AddMeetingCommand) other).dateTime)
-                && attendeeNames.equals(((AddMeetingCommand) other).attendeeNames)
-                && location.equals(((AddMeetingCommand) other).location)
-                && description.equals(((AddMeetingCommand) other).description));
+            || (other instanceof AddMeetingCommand // instanceof handles nulls
+            && meetingTitle.equals(((AddMeetingCommand) other).meetingTitle)
+            && dateTime.equals(((AddMeetingCommand) other).dateTime)
+            && attendeeNames.equals(((AddMeetingCommand) other).attendeeNames)
+            && location.equals(((AddMeetingCommand) other).location)
+            && description.equals(((AddMeetingCommand) other).description));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -1,5 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING_TITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
 import seedu.address.logic.commands.AddMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.meeting.DateTime;
@@ -8,12 +18,9 @@ import seedu.address.model.meeting.Location;
 import seedu.address.model.meeting.Title;
 import seedu.address.model.person.Name;
 
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
-
+/**
+ * Parses input arguments and creates a new AddMeetingCommand object.
+ */
 public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
@@ -26,12 +33,12 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
     @Override
     public AddMeetingCommand parse(String userInput) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(userInput, PREFIX_MEETING_TITLE, PREFIX_PERSON, PREFIX_DATE,
-                        PREFIX_LOCATION, PREFIX_DESCRIPTION);
+            ArgumentTokenizer.tokenize(userInput, PREFIX_MEETING_TITLE, PREFIX_PERSON, PREFIX_DATE,
+                PREFIX_LOCATION, PREFIX_DESCRIPTION);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_MEETING_TITLE, PREFIX_DATE, PREFIX_PERSON, PREFIX_LOCATION,
-                PREFIX_DESCRIPTION)
-                || !argMultimap.getPreamble().isEmpty()) {
+            PREFIX_DESCRIPTION)
+            || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.AddMeetingCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.meeting.DateTime;
+import seedu.address.model.meeting.Description;
+import seedu.address.model.meeting.Location;
+import seedu.address.model.meeting.Title;
+import seedu.address.model.person.Name;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    @Override
+    public AddMeetingCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(userInput, PREFIX_MEETING_TITLE, PREFIX_PERSON, PREFIX_DATE,
+                        PREFIX_LOCATION, PREFIX_DESCRIPTION);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_MEETING_TITLE, PREFIX_DATE, PREFIX_PERSON, PREFIX_LOCATION,
+                PREFIX_DESCRIPTION)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE));
+        }
+
+        Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_MEETING_TITLE).get());
+        Set<Name> attendeeNames = ParserUtil.parseNames(argMultimap.getAllValues(PREFIX_PERSON));
+        DateTime dateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATE).get());
+        Location location = ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get());
+        Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
+
+        return new AddMeetingCommand(title, dateTime, attendeeNames, location, description);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING_TITLE;
@@ -33,10 +33,10 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
     @Override
     public AddMeetingCommand parse(String userInput) throws ParseException {
         ArgumentMultimap argMultimap =
-            ArgumentTokenizer.tokenize(userInput, PREFIX_MEETING_TITLE, PREFIX_PERSON, PREFIX_DATE,
+            ArgumentTokenizer.tokenize(userInput, PREFIX_MEETING_TITLE, PREFIX_PERSON, PREFIX_DATETIME,
                 PREFIX_LOCATION, PREFIX_DESCRIPTION);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_MEETING_TITLE, PREFIX_DATE, PREFIX_PERSON, PREFIX_LOCATION,
+        if (!arePrefixesPresent(argMultimap, PREFIX_MEETING_TITLE, PREFIX_DATETIME, PREFIX_PERSON, PREFIX_LOCATION,
             PREFIX_DESCRIPTION)
             || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE));
@@ -44,7 +44,7 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_MEETING_TITLE).get());
         Set<Name> attendeeNames = ParserUtil.parseNames(argMultimap.getAllValues(PREFIX_PERSON));
-        DateTime dateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATE).get());
+        DateTime dateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
         Location location = ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get());
         Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -1,12 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddMeetingCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -17,6 +12,12 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ViewMeetingsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 /**
  * Parses user input.
@@ -68,6 +69,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AddMeetingCommand.COMMAND_WORD:
+            return new AddMeetingCommandParser().parse(arguments);
 
         case ViewMeetingsCommand.COMMAND_WORD:
             return new ViewMeetingsCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -1,5 +1,11 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddMeetingCommand;
 import seedu.address.logic.commands.ClearCommand;
@@ -12,12 +18,6 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ViewMeetingsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 /**
  * Parses user input.

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,7 +12,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_MEETING_TITLE = new Prefix("m/");
-    public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_DATETIME = new Prefix("dt/");
     public static final Prefix PREFIX_LOCATION = new Prefix("l/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("des/");
     public static final Prefix PREFIX_PERSON = new Prefix("p/");

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,10 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_MEETING_TITLE = new Prefix("m/");
+    public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_LOCATION = new Prefix("l/");
+    public static final Prefix PREFIX_DESCRIPTION = new Prefix("des/");
+    public static final Prefix PREFIX_PERSON = new Prefix("p/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,5 +1,11 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -13,12 +19,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
  */
@@ -29,6 +29,7 @@ public class ParserUtil {
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -56,6 +57,7 @@ public class ParserUtil {
 
     /**
      * Parses a Collection of {@code String names} to a set of {@code Name}.
+     *
      * @param names A collection of names.
      * @return A set of names.
      * @throws ParseException if any of the given names is invalid.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,19 +1,23 @@
 package seedu.address.logic.parser;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.meeting.DateTime;
+import seedu.address.model.meeting.Description;
+import seedu.address.model.meeting.Location;
+import seedu.address.model.meeting.Title;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -48,6 +52,21 @@ public class ParserUtil {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
         return new Name(trimmedName);
+    }
+
+    /**
+     * Parses a Collection of {@code String names} to a set of {@code Name}.
+     * @param names A collection of names.
+     * @return A set of names.
+     * @throws ParseException if any of the given names is invalid.
+     */
+    public static Set<Name> parseNames(Collection<String> names) throws ParseException {
+        requireNonNull(names);
+        final Set<Name> nameSet = new HashSet<>();
+        for (String name : names) {
+            nameSet.add(parseName(name));
+        }
+        return nameSet;
     }
 
     /**
@@ -120,5 +139,65 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String title} into a {@code Title}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code title} is invalid.
+     */
+    public static Title parseTitle(String title) throws ParseException {
+        requireNonNull(title);
+        String trimmedTitle = title.trim();
+        if (!Title.isValidTitle(trimmedTitle)) {
+            throw new ParseException(Title.MESSAGE_CONSTRAINTS);
+        }
+        return new Title(trimmedTitle);
+    }
+
+    /**
+     * Parses a {@code String datetime} into a {@code DateTime}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code datetime} is invalid.
+     */
+    public static DateTime parseDateTime(String dateTime) throws ParseException {
+        requireNonNull(dateTime);
+        String trimmedDateTime = dateTime.trim();
+        if (!DateTime.isValidDateTime(trimmedDateTime)) {
+            throw new ParseException(DateTime.MESSAGE_CONSTRAINTS);
+        }
+        return new DateTime(trimmedDateTime);
+    }
+
+    /**
+     * Parses a {@code String location} into a {@code Location}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code location} is invalid.
+     */
+    public static Location parseLocation(String s) throws ParseException {
+        requireNonNull(s);
+        String trimmedLocation = s.trim();
+        if (!Location.isValidLocation(trimmedLocation)) {
+            throw new ParseException(Location.MESSAGE_CONSTRAINTS);
+        }
+        return new Location(trimmedLocation);
+    }
+
+    /**
+     * Parses a {@code String description} into a {@code Description}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code description} is invalid.
+     */
+    public static Description parseDescription(String s) throws ParseException {
+        requireNonNull(s);
+        String trimmedDescription = s.trim();
+        if (!Description.isValidDescription(trimmedDescription)) {
+            throw new ParseException(Description.MESSAGE_CONSTRAINTS);
+        }
+        return new Description(trimmedDescription);
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,16 +1,16 @@
 package seedu.address.model;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Objects;
+
 import javafx.collections.ObservableList;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.UniqueMeetingList;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
-
-import java.util.List;
-import java.util.Objects;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Wraps all data at the address-book level
@@ -33,7 +33,8 @@ public class AddressBook implements ReadOnlyAddressBook {
         meetings = new UniqueMeetingList();
     }
 
-    public AddressBook() {}
+    public AddressBook() {
+    }
 
     /**
      * Creates an AddressBook using the Persons in the {@code toBeCopied}
@@ -156,7 +157,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public String toString() {
         return persons.asUnmodifiableObservableList().size() + " persons\n"
-                + meetings.asUnmodifiableObservableList().size() + " meetings";
+            + meetings.asUnmodifiableObservableList().size() + " meetings";
         // TODO: refine later
     }
 
@@ -173,9 +174,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof AddressBook // instanceof handles nulls
-                && persons.equals(((AddressBook) other).persons)
-                && meetings.equals(((AddressBook) other).meetings));
+            || (other instanceof AddressBook // instanceof handles nulls
+            && persons.equals(((AddressBook) other).persons)
+            && meetings.equals(((AddressBook) other).meetings));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,15 +1,16 @@
 package seedu.address.model;
 
-import static java.util.Objects.requireNonNull;
+import javafx.collections.ObservableList;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.UniqueMeetingList;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.UniquePersonList;
 
 import java.util.List;
 import java.util.Objects;
 
-import javafx.collections.ObservableList;
-import seedu.address.model.meeting.Meeting;
-import seedu.address.model.meeting.UniqueMeetingList;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.UniquePersonList;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Wraps all data at the address-book level
@@ -86,6 +87,11 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addPerson(Person p) {
         persons.add(p);
+    }
+
+    public Person getPersonByName(Name personName) {
+        requireNonNull(personName);
+        return persons.getPersonByName(personName);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,30 +1,32 @@
 package seedu.address.model;
 
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 
-import java.nio.file.Path;
-import java.util.function.Predicate;
-
 /**
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
-    Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
-
     /**
-     * Replaces user prefs data with the data in {@code userPrefs}.
+     * {@code Predicate} that always evaluate to true
      */
-    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
+    Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
     /**
      * Returns the user prefs.
      */
     ReadOnlyUserPrefs getUserPrefs();
+
+    /**
+     * Replaces user prefs data with the data in {@code userPrefs}.
+     */
+    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
 
     /**
      * Returns the user prefs' GUI settings.
@@ -47,12 +49,14 @@ public interface Model {
     void setAddressBookFilePath(Path addressBookFilePath);
 
     /**
+     * Returns the AddressBook
+     */
+    ReadOnlyAddressBook getAddressBook();
+
+    /**
      * Replaces address book data with the data in {@code addressBook}.
      */
     void setAddressBook(ReadOnlyAddressBook addressBook);
-
-    /** Returns the AddressBook */
-    ReadOnlyAddressBook getAddressBook();
 
     /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
@@ -80,16 +84,20 @@ public interface Model {
 
     /**
      * Gets the Person matching the name from the address book.
+     *
      * @param personName name of the person to be retrieved.
      * @return the person with the given name.
      */
     Person getPersonByName(Name personName);
 
-    /** Returns an unmodifiable view of the filtered person list */
+    /**
+     * Returns an unmodifiable view of the filtered person list
+     */
     ObservableList<Person> getFilteredPersonList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
@@ -105,6 +113,8 @@ public interface Model {
      */
     boolean hasMeeting(Meeting meeting);
 
-    /** Returns an unmodifiable view of the meetings list */
+    /**
+     * Returns an unmodifiable view of the meetings list
+     */
     ObservableList<Meeting> getMeetingsList();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,12 +1,13 @@
 package seedu.address.model;
 
-import java.nio.file.Path;
-import java.util.function.Predicate;
-
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
 
 /**
  * The API of the Model component.
@@ -77,6 +78,13 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Gets the Person matching the name from the address book.
+     * @param personName name of the person to be retrieved.
+     * @return the person with the given name.
+     */
+    Person getPersonByName(Name personName);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
@@ -85,6 +93,17 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Adds the given meeting.
+     * {@code meeting} must not already exist in the meeting list.
+     */
+    void addMeeting(Meeting meeting);
+
+    /**
+     * Returns true if a meeting with the same identity/name as {@code meeting} exists in the address book.
+     */
+    boolean hasMeeting(Meeting meeting);
 
     /** Returns an unmodifiable view of the meetings list */
     ObservableList<Meeting> getMeetingsList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,18 +1,19 @@
 package seedu.address.model;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-
-import java.nio.file.Path;
-import java.util.function.Predicate;
-import java.util.logging.Logger;
-
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -114,6 +115,10 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    @Override
+    public Person getPersonByName(Name personName) {
+        return addressBook.getPersonByName(personName);
+    }
     //=========== Filtered Person List Accessors =============================================================
 
     /**
@@ -151,6 +156,18 @@ public class ModelManager implements Model {
     }
 
     //================= Meeting accessors ==================//
+    @Override
+    public void addMeeting(Meeting meeting) {
+        addressBook.addMeeting(meeting);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    @Override
+    public boolean hasMeeting(Meeting meeting) {
+        requireNonNull(meeting);
+        return addressBook.hasMeeting(meeting);
+    }
+
     /**
      * Returns an unmodifiable view of the list of {@code Meeting} backed by the internal list of
      * {@code versionedAddressBook}

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,5 +1,12 @@
 package seedu.address.model;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
@@ -7,13 +14,6 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-
-import java.nio.file.Path;
-import java.util.function.Predicate;
-import java.util.logging.Logger;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -47,14 +47,14 @@ public class ModelManager implements Model {
     //=========== UserPrefs ==================================================================================
 
     @Override
-    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-        requireNonNull(userPrefs);
-        this.userPrefs.resetData(userPrefs);
+    public ReadOnlyUserPrefs getUserPrefs() {
+        return userPrefs;
     }
 
     @Override
-    public ReadOnlyUserPrefs getUserPrefs() {
-        return userPrefs;
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        requireNonNull(userPrefs);
+        this.userPrefs.resetData(userPrefs);
     }
 
     @Override
@@ -82,13 +82,13 @@ public class ModelManager implements Model {
     //=========== AddressBook ================================================================================
 
     @Override
-    public void setAddressBook(ReadOnlyAddressBook addressBook) {
-        this.addressBook.resetData(addressBook);
+    public ReadOnlyAddressBook getAddressBook() {
+        return addressBook;
     }
 
     @Override
-    public ReadOnlyAddressBook getAddressBook() {
-        return addressBook;
+    public void setAddressBook(ReadOnlyAddressBook addressBook) {
+        this.addressBook.resetData(addressBook);
     }
 
     @Override
@@ -151,8 +151,8 @@ public class ModelManager implements Model {
         // state check
         ModelManager other = (ModelManager) obj;
         return addressBook.equals(other.addressBook)
-                && userPrefs.equals(other.userPrefs)
-                && filteredPersons.equals(other.filteredPersons);
+            && userPrefs.equals(other.userPrefs)
+            && filteredPersons.equals(other.filteredPersons);
     }
 
     //================= Meeting accessors ==================//

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -1,15 +1,15 @@
 package seedu.address.model.person;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
-import seedu.address.model.person.exceptions.PersonNotFoundException;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
@@ -26,7 +26,7 @@ public class UniquePersonList implements Iterable<Person> {
 
     private final ObservableList<Person> internalList = FXCollections.observableArrayList();
     private final ObservableList<Person> internalUnmodifiableList =
-            FXCollections.unmodifiableObservableList(internalList);
+        FXCollections.unmodifiableObservableList(internalList);
 
     /**
      * Returns true if the list contains an equivalent person as the given argument.
@@ -70,8 +70,9 @@ public class UniquePersonList implements Iterable<Person> {
 
     /**
      * A simpler way of getting a person by name from address book.
+     *
      * @param name of the person to be found
-     * @return  the person with the given name if they are in the list, null otherwise
+     * @return the person with the given name if they are in the list, null otherwise
      */
     public Person getPersonByName(Name name) {
         requireNonNull(name);
@@ -127,8 +128,8 @@ public class UniquePersonList implements Iterable<Person> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof UniquePersonList // instanceof handles nulls
-                        && internalList.equals(((UniquePersonList) other).internalList));
+            || (other instanceof UniquePersonList // instanceof handles nulls
+            && internalList.equals(((UniquePersonList) other).internalList));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -1,15 +1,15 @@
 package seedu.address.model.person;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-
-import java.util.Iterator;
-import java.util.List;
-
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
@@ -17,7 +17,7 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
  * persons uses Person#isSamePerson(Person) for equality so as to ensure that the person being added or updated is
  * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) so
  * as to ensure that the person with exactly the same fields will be removed.
- *
+ * <p>
  * Supports a minimal set of list operations.
  *
  * @see Person#isSamePerson(Person)
@@ -66,6 +66,21 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.set(index, editedPerson);
+    }
+
+    /**
+     * A simpler way of getting a person by name from address book.
+     * @param name of the person to be found
+     * @return  the person with the given name if they are in the list, null otherwise
+     */
+    public Person getPersonByName(Name name) {
+        requireNonNull(name);
+        for (Person person : internalList) {
+            if (person.getName().equals(name)) {
+                return person;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -1,19 +1,7 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.Assert.assertThrows;
-
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.function.Predicate;
-
-import org.junit.jupiter.api.Test;
-
 import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
@@ -21,8 +9,18 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.testutil.Assert.assertThrows;
 
 public class AddCommandTest {
 
@@ -80,12 +78,12 @@ public class AddCommandTest {
      */
     private class ModelStub implements Model {
         @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        public ReadOnlyUserPrefs getUserPrefs() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -115,12 +113,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
+        public ReadOnlyAddressBook getAddressBook() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public ReadOnlyAddressBook getAddressBook() {
+        public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -139,6 +137,7 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+
         @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
@@ -146,6 +145,21 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addMeeting(Meeting meeting) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasMeeting(Meeting meeting) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Person getPersonByName(Name personName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -1,7 +1,19 @@
 package seedu.address.logic.commands;
 
-import javafx.collections.ObservableList;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
@@ -12,15 +24,6 @@ import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
-
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.function.Predicate;
-
-import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.address.testutil.Assert.assertThrows;
 
 public class AddCommandTest {
 

--- a/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
@@ -1,0 +1,185 @@
+package seedu.address.logic.commands;
+
+import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.MeetingBuilder;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalMeetings.MEETING_A;
+import static seedu.address.testutil.TypicalMeetings.MEETING_B;
+import static seedu.address.testutil.TypicalPersons.*;
+
+public class AddMeetingCommandTest {
+
+    @Test
+    public void constructor_nullMeeting_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddMeetingCommand(null, null,
+                null, null, null));
+    }
+
+    @Test
+    public void execute_meetingAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubWithPersons modelStub = new ModelStubWithPersons(BENSON, CARL);
+        Meeting validMeeting = new MeetingBuilder(MEETING_B).build();
+
+        CommandResult commandResult = new AddMeetingCommand(MEETING_B.getTitle(), MEETING_B.getDateTime(),
+                new HashSet<>(Arrays.asList(BENSON.getName(), CARL.getName())),
+                MEETING_B.getLocation(), MEETING_B.getDescription())
+                .execute(modelStub);
+
+        assertEquals(String.format(AddMeetingCommand.MESSAGE_SUCCESS, validMeeting), commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_duplicateMeeting_throwsCommandException() {
+        AddMeetingCommand addMeetingCommand = new AddMeetingCommand(MEETING_A.getTitle(), MEETING_A.getDateTime(),
+                new HashSet<>(Collections.singletonList(ALICE.getName())),
+                MEETING_A.getLocation(), MEETING_A.getDescription());
+        ModelStub modelStub = new ModelStubWithPersons(ALICE, CARL);
+
+        assertThrows(CommandException.class, AddMeetingCommand.MESSAGE_DUPLICATE_MEETING,
+                () -> addMeetingCommand.execute(modelStub));
+    }
+
+    /**
+     * A default model stub that have all the methods failing.
+     */
+    private static class ModelStub implements Model {
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addMeeting(Meeting meeting) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasMeeting(Meeting meeting) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Person getPersonByName(Name personName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Meeting> getMeetingsList() {
+            throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub that contains a single person.
+     */
+    private static class ModelStubWithPersons extends AddMeetingCommandTest.ModelStub {
+        private final Person person1;
+        private final Person person2;
+
+        ModelStubWithPersons(Person person1, Person person2) {
+            this.person1 = person1;
+            this.person2 = person2;
+        }
+
+        @Override
+        public Person getPersonByName(Name personName) {
+            return person1.getName().equals(personName) ? person1 : person2;
+        }
+
+        @Override
+        public boolean hasMeeting(Meeting meeting) {
+            requireNonNull(meeting);
+            return MEETING_A.isSameMeeting(meeting);
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return this.person1.isSamePerson(person) || this.person2.isSamePerson(person);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
@@ -1,7 +1,23 @@
 package seedu.address.logic.commands;
 
-import javafx.collections.ObservableList;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalMeetings.MEETING_A;
+import static seedu.address.testutil.TypicalMeetings.MEETING_B;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.CARL;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -12,25 +28,12 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.MeetingBuilder;
 
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.function.Predicate;
-
-import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalMeetings.MEETING_A;
-import static seedu.address.testutil.TypicalMeetings.MEETING_B;
-import static seedu.address.testutil.TypicalPersons.*;
-
 public class AddMeetingCommandTest {
 
     @Test
     public void constructor_nullMeeting_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AddMeetingCommand(null, null,
-                null, null, null));
+            null, null, null));
     }
 
     @Test
@@ -39,9 +42,9 @@ public class AddMeetingCommandTest {
         Meeting validMeeting = new MeetingBuilder(MEETING_B).build();
 
         CommandResult commandResult = new AddMeetingCommand(MEETING_B.getTitle(), MEETING_B.getDateTime(),
-                new HashSet<>(Arrays.asList(BENSON.getName(), CARL.getName())),
-                MEETING_B.getLocation(), MEETING_B.getDescription())
-                .execute(modelStub);
+            new HashSet<>(Arrays.asList(BENSON.getName(), CARL.getName())),
+            MEETING_B.getLocation(), MEETING_B.getDescription())
+            .execute(modelStub);
 
         assertEquals(String.format(AddMeetingCommand.MESSAGE_SUCCESS, validMeeting), commandResult.getFeedbackToUser());
     }
@@ -49,12 +52,12 @@ public class AddMeetingCommandTest {
     @Test
     public void execute_duplicateMeeting_throwsCommandException() {
         AddMeetingCommand addMeetingCommand = new AddMeetingCommand(MEETING_A.getTitle(), MEETING_A.getDateTime(),
-                new HashSet<>(Collections.singletonList(ALICE.getName())),
-                MEETING_A.getLocation(), MEETING_A.getDescription());
+            new HashSet<>(Collections.singletonList(ALICE.getName())),
+            MEETING_A.getLocation(), MEETING_A.getDescription());
         ModelStub modelStub = new ModelStubWithPersons(ALICE, CARL);
 
-        assertThrows(CommandException.class, AddMeetingCommand.MESSAGE_DUPLICATE_MEETING,
-                () -> addMeetingCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddMeetingCommand.MESSAGE_DUPLICATE_MEETING, () ->
+            addMeetingCommand.execute(modelStub));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -1,18 +1,5 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.testutil.Assert.assertThrows;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
@@ -21,6 +8,15 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.testutil.Assert.assertThrows;
+
 /**
  * Contains helper methods for testing commands.
  */
@@ -28,6 +24,7 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
+    public static final String VALID_NAME_ALICE = "Alice Pauline";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
@@ -39,6 +36,7 @@ public class CommandTestUtil {
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
+    public static final String NAME_DESC_ALICE = " " + PREFIX_NAME + VALID_NAME_ALICE;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
     public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
     public static final String EMAIL_DESC_AMY = " " + PREFIX_EMAIL + VALID_EMAIL_AMY;
@@ -62,6 +60,13 @@ public class CommandTestUtil {
     public static final String VALID_MEETING_LOCATION = "In school";
     public static final String VALID_MEETING_DESCRIPTION = "Finish up school project (computer science)";
 
+    public static final String MEETING_TITLE_DESC = " " + PREFIX_MEETING_TITLE + VALID_MEETING_TITLE;
+    public static final String MEETING_PERSON_ALICE_DESC = " " + PREFIX_PERSON + "Alice Pauline";
+    public static final String MEETING_PERSON_BENSON_DESC = " " + PREFIX_PERSON + "Benson Meier";
+    public static final String MEETING_DATETIME_DESC = " " + PREFIX_DATE + VALID_MEETING_DATETIME;
+    public static final String MEETING_LOCATION_DESC = " " + PREFIX_LOCATION + VALID_MEETING_LOCATION;
+    public static final String MEETING_DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION + VALID_MEETING_DESCRIPTION;
+
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
 
@@ -80,7 +85,7 @@ public class CommandTestUtil {
      * - the {@code actualModel} matches {@code expectedModel}
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
-            Model expectedModel) {
+                                            Model expectedModel) {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
@@ -95,7 +100,7 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-            Model expectedModel) {
+                                            Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
@@ -116,6 +121,7 @@ public class CommandTestUtil {
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
@@ -125,7 +131,7 @@ public class CommandTestUtil {
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Collections.singletonList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
@@ -72,7 +72,7 @@ public class CommandTestUtil {
     public static final String MEETING_TITLE_DESC = " " + PREFIX_MEETING_TITLE + VALID_MEETING_TITLE;
     public static final String MEETING_PERSON_ALICE_DESC = " " + PREFIX_PERSON + "Alice Pauline";
     public static final String MEETING_PERSON_BENSON_DESC = " " + PREFIX_PERSON + "Benson Meier";
-    public static final String MEETING_DATETIME_DESC = " " + PREFIX_DATE + VALID_MEETING_DATETIME;
+    public static final String MEETING_DATETIME_DESC = " " + PREFIX_DATETIME + VALID_MEETING_DATETIME;
     public static final String MEETING_LOCATION_DESC = " " + PREFIX_LOCATION + VALID_MEETING_LOCATION;
     public static final String MEETING_DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION + VALID_MEETING_DESCRIPTION;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -1,5 +1,23 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING_TITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
@@ -7,15 +25,6 @@ import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.CliSyntax.*;
-import static seedu.address.testutil.Assert.assertThrows;
 
 /**
  * Contains helper methods for testing commands.
@@ -72,11 +81,11 @@ public class CommandTestUtil {
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
+            .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
+            .withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+            .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
+            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
@@ -1,11 +1,5 @@
 package seedu.address.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.logic.commands.AddMeetingCommand;
-import seedu.address.model.meeting.Meeting;
-import seedu.address.testutil.MeetingBuilder;
-import seedu.address.testutil.TypicalPersons;
-
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.MEETING_DATETIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.MEETING_DESCRIPTION_DESC;
@@ -23,39 +17,47 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_TITLE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddMeetingCommand;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.testutil.MeetingBuilder;
+import seedu.address.testutil.TypicalPersons;
+
 public class AddMeetingCommandParserTest {
     private final AddMeetingCommandParser parser = new AddMeetingCommandParser();
 
     @Test
     public void parse_allFieldsPresent_success() {
         Meeting expectedMeetingWithOnePerson = new MeetingBuilder().withTitle(VALID_MEETING_TITLE)
-                .withDateTime(VALID_MEETING_DATETIME).withAttendees(TypicalPersons.ALICE).withLocation(VALID_MEETING_LOCATION)
-                .withDescription(VALID_MEETING_DESCRIPTION).build();
+            .withDateTime(VALID_MEETING_DATETIME).withAttendees(TypicalPersons.ALICE)
+            .withLocation(VALID_MEETING_LOCATION)
+            .withDescription(VALID_MEETING_DESCRIPTION).build();
         Meeting expectedMeetingWithTwoPersons = new MeetingBuilder().withTitle(VALID_MEETING_TITLE)
-                .withDateTime(VALID_MEETING_DATETIME).withAttendees(TypicalPersons.ALICE, TypicalPersons.BENSON)
-                .withLocation(VALID_MEETING_LOCATION).withDescription(VALID_MEETING_DESCRIPTION).build();
+            .withDateTime(VALID_MEETING_DATETIME).withAttendees(TypicalPersons.ALICE, TypicalPersons.BENSON)
+            .withLocation(VALID_MEETING_LOCATION).withDescription(VALID_MEETING_DESCRIPTION).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + MEETING_TITLE_DESC + MEETING_DATETIME_DESC
-                        + MEETING_PERSON_ALICE_DESC + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC,
-                new AddMeetingCommand(expectedMeetingWithOnePerson));
+                + MEETING_PERSON_ALICE_DESC + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC,
+            new AddMeetingCommand(expectedMeetingWithOnePerson));
 
         // no whitespace preamble
         assertParseSuccess(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC
-                        + MEETING_PERSON_ALICE_DESC + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC,
-                new AddMeetingCommand(expectedMeetingWithOnePerson));
+                + MEETING_PERSON_ALICE_DESC + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC,
+            new AddMeetingCommand(expectedMeetingWithOnePerson));
 
         // whitespace only preamble and multiple persons
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + MEETING_TITLE_DESC + MEETING_DATETIME_DESC
-                        + MEETING_PERSON_ALICE_DESC + MEETING_PERSON_BENSON_DESC + MEETING_LOCATION_DESC
-                        + MEETING_DESCRIPTION_DESC,
-                new AddMeetingCommand(expectedMeetingWithTwoPersons));
+                + MEETING_PERSON_ALICE_DESC + MEETING_PERSON_BENSON_DESC + MEETING_LOCATION_DESC
+                + MEETING_DESCRIPTION_DESC,
+            new AddMeetingCommand(expectedMeetingWithTwoPersons));
 
         // no whitespace only preamble and multiple persons
         assertParseSuccess(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC
-                        + MEETING_PERSON_ALICE_DESC + MEETING_PERSON_BENSON_DESC + MEETING_LOCATION_DESC
-                        + MEETING_DESCRIPTION_DESC,
-                new AddMeetingCommand(expectedMeetingWithTwoPersons));
+                + MEETING_PERSON_ALICE_DESC + MEETING_PERSON_BENSON_DESC + MEETING_LOCATION_DESC
+                + MEETING_DESCRIPTION_DESC,
+            new AddMeetingCommand(expectedMeetingWithTwoPersons));
     }
 
     @Test
@@ -64,26 +66,26 @@ public class AddMeetingCommandParserTest {
 
         // missing title prefix
         assertParseFailure(parser, VALID_MEETING_TITLE + MEETING_DATETIME_DESC + MEETING_PERSON_ALICE_DESC
-                + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC, expectedMessage);
+            + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC, expectedMessage);
 
         // missing datetime prefix
         assertParseFailure(parser, MEETING_TITLE_DESC + VALID_MEETING_DATETIME + MEETING_PERSON_ALICE_DESC
-                + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC, expectedMessage);
+            + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC, expectedMessage);
 
         // missing person prefix
         assertParseFailure(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC + NAME_DESC_AMY
-                + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC, expectedMessage);
+            + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC, expectedMessage);
 
         // missing location prefix
         assertParseFailure(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC + MEETING_PERSON_ALICE_DESC
-                + VALID_MEETING_LOCATION + MEETING_DESCRIPTION_DESC, expectedMessage);
+            + VALID_MEETING_LOCATION + MEETING_DESCRIPTION_DESC, expectedMessage);
 
         // missing description prefix
         assertParseFailure(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC + MEETING_PERSON_ALICE_DESC
-                + MEETING_LOCATION_DESC + VALID_MEETING_DESCRIPTION, expectedMessage);
+            + MEETING_LOCATION_DESC + VALID_MEETING_DESCRIPTION, expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_MEETING_TITLE + VALID_MEETING_DATETIME + NAME_DESC_ALICE
-                + VALID_MEETING_LOCATION + VALID_MEETING_DESCRIPTION, expectedMessage);
+            + VALID_MEETING_LOCATION + VALID_MEETING_DESCRIPTION, expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.AddMeetingCommand;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.testutil.MeetingBuilder;
+import seedu.address.testutil.TypicalPersons;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.MEETING_DATETIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MEETING_DESCRIPTION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MEETING_LOCATION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MEETING_PERSON_ALICE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MEETING_PERSON_BENSON_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MEETING_TITLE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_DATETIME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_DESCRIPTION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_LOCATION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_TITLE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+public class AddMeetingCommandParserTest {
+    private final AddMeetingCommandParser parser = new AddMeetingCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Meeting expectedMeetingWithOnePerson = new MeetingBuilder().withTitle(VALID_MEETING_TITLE)
+                .withDateTime(VALID_MEETING_DATETIME).withAttendees(TypicalPersons.ALICE).withLocation(VALID_MEETING_LOCATION)
+                .withDescription(VALID_MEETING_DESCRIPTION).build();
+        Meeting expectedMeetingWithTwoPersons = new MeetingBuilder().withTitle(VALID_MEETING_TITLE)
+                .withDateTime(VALID_MEETING_DATETIME).withAttendees(TypicalPersons.ALICE, TypicalPersons.BENSON)
+                .withLocation(VALID_MEETING_LOCATION).withDescription(VALID_MEETING_DESCRIPTION).build();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + MEETING_TITLE_DESC + MEETING_DATETIME_DESC
+                        + MEETING_PERSON_ALICE_DESC + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC,
+                new AddMeetingCommand(expectedMeetingWithOnePerson));
+
+        // no whitespace preamble
+        assertParseSuccess(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC
+                        + MEETING_PERSON_ALICE_DESC + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC,
+                new AddMeetingCommand(expectedMeetingWithOnePerson));
+
+        // whitespace only preamble and multiple persons
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + MEETING_TITLE_DESC + MEETING_DATETIME_DESC
+                        + MEETING_PERSON_ALICE_DESC + MEETING_PERSON_BENSON_DESC + MEETING_LOCATION_DESC
+                        + MEETING_DESCRIPTION_DESC,
+                new AddMeetingCommand(expectedMeetingWithTwoPersons));
+
+        // no whitespace only preamble and multiple persons
+        assertParseSuccess(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC
+                        + MEETING_PERSON_ALICE_DESC + MEETING_PERSON_BENSON_DESC + MEETING_LOCATION_DESC
+                        + MEETING_DESCRIPTION_DESC,
+                new AddMeetingCommand(expectedMeetingWithTwoPersons));
+    }
+
+    @Test
+    public void parse_compulsoryFieldsMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE);
+
+        // missing title prefix
+        assertParseFailure(parser, VALID_MEETING_TITLE + MEETING_DATETIME_DESC + MEETING_PERSON_ALICE_DESC
+                + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC, expectedMessage);
+
+        // missing datetime prefix
+        assertParseFailure(parser, MEETING_TITLE_DESC + VALID_MEETING_DATETIME + MEETING_PERSON_ALICE_DESC
+                + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC, expectedMessage);
+
+        // missing person prefix
+        assertParseFailure(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC + NAME_DESC_AMY
+                + MEETING_LOCATION_DESC + MEETING_DESCRIPTION_DESC, expectedMessage);
+
+        // missing location prefix
+        assertParseFailure(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC + MEETING_PERSON_ALICE_DESC
+                + VALID_MEETING_LOCATION + MEETING_DESCRIPTION_DESC, expectedMessage);
+
+        // missing description prefix
+        assertParseFailure(parser, MEETING_TITLE_DESC + MEETING_DATETIME_DESC + MEETING_PERSON_ALICE_DESC
+                + MEETING_LOCATION_DESC + VALID_MEETING_DESCRIPTION, expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_MEETING_TITLE + VALID_MEETING_DATETIME + NAME_DESC_ALICE
+                + VALID_MEETING_LOCATION + VALID_MEETING_DESCRIPTION, expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,6 +1,18 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.meeting.DateTime;
 import seedu.address.model.meeting.Description;
@@ -11,17 +23,6 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
@@ -140,7 +141,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseAddress_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseAddress( null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseAddress(null));
     }
 
     @Test
@@ -163,7 +164,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseEmail_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail( null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail(null));
     }
 
     @Test
@@ -254,69 +255,69 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void ParseDateTime_null_throwsNullPointerException() {
+    public void parseDateTime_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseDateTime(null));
     }
 
     @Test
-    public void ParseDateTime_invalidValue_throwsParseException() {
+    public void parseDateTime_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseDateTime(INVALID_DATETIME));
     }
 
     @Test
-    public void ParseDateTime_validValueWithoutWhitespace_returnsDateTime() throws Exception {
+    public void parseDateTime_validValueWithoutWhitespace_returnsDateTime() throws Exception {
         DateTime expectedDateTime = new DateTime(VALID_DATETIME);
         assertEquals(expectedDateTime, ParserUtil.parseDateTime(VALID_DATETIME));
     }
 
     @Test
-    public void ParseDateTime_validValueWithWhitespace_returnsTrimmedDateTime() throws Exception {
+    public void parseDateTime_validValueWithWhitespace_returnsTrimmedDateTime() throws Exception {
         String dateTimeWithWhitespace = WHITESPACE + VALID_DATETIME + WHITESPACE;
         DateTime expectedDateTime = new DateTime(VALID_DATETIME);
         assertEquals(expectedDateTime, ParserUtil.parseDateTime(dateTimeWithWhitespace));
     }
 
     @Test
-    public void ParseLocation_null_throwsNullPointerException() {
+    public void parseLocation_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseLocation(null));
     }
 
     @Test
-    public void ParseLocation_invalidValue_throwsParseException() {
+    public void parseLocation_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseLocation(INVALID_LOCATION));
     }
 
     @Test
-    public void ParseLocation_validValueWithoutWhitespace_returnsLocation() throws Exception {
+    public void parseLocation_validValueWithoutWhitespace_returnsLocation() throws Exception {
         Location expectedLocation = new Location(VALID_LOCATION);
         assertEquals(expectedLocation, ParserUtil.parseLocation(VALID_LOCATION));
     }
 
     @Test
-    public void ParseLocation_validValueWithWhitespace_returnsTrimmedLocation() throws Exception {
+    public void parseLocation_validValueWithWhitespace_returnsTrimmedLocation() throws Exception {
         String locationWithWhitespace = WHITESPACE + VALID_LOCATION + WHITESPACE;
         Location expectedLocation = new Location(VALID_LOCATION);
         assertEquals(expectedLocation, ParserUtil.parseLocation(locationWithWhitespace));
     }
 
     @Test
-    public void ParseDescription_null_throwsNullPointerException() {
+    public void parseDescription_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseDescription(null));
     }
 
     @Test
-    public void ParseDescription_invalidValue_throwsParseException() {
+    public void parseDescription_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseDescription(INVALID_DESCRIPTION));
     }
 
     @Test
-    public void ParseDescription_validValueWithoutWhitespace_returnsDescription() throws Exception {
+    public void parseDescription_validValueWithoutWhitespace_returnsDescription() throws Exception {
         Description expectedDescription = new Description(VALID_DESCRIPTION);
         assertEquals(expectedDescription, ParserUtil.parseDescription(VALID_DESCRIPTION));
     }
 
     @Test
-    public void ParseDescription_validValueWithWhitespace_returnsTrimmedDescription() throws Exception {
+    public void parseDescription_validValueWithWhitespace_returnsTrimmedDescription() throws Exception {
         String descriptionWithWhitespace = WHITESPACE + VALID_DESCRIPTION + WHITESPACE;
         Description expectedDescription = new Description(VALID_DESCRIPTION);
         assertEquals(expectedDescription, ParserUtil.parseDescription(descriptionWithWhitespace));

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,33 +1,46 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.junit.jupiter.api.Test;
-
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.meeting.DateTime;
+import seedu.address.model.meeting.Description;
+import seedu.address.model.meeting.Location;
+import seedu.address.model.meeting.Title;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_TITLE = "ME3T!NG 1";
+    private static final String INVALID_DATETIME = "2020-02-30 12:00";
+    private static final String INVALID_LOCATION = "!@#$%^&*()";
+    private static final String INVALID_DESCRIPTION = "()#&($#)";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
 
+
     private static final String VALID_NAME = "Rachel Walker";
+    private static final String VALID_NAME_2 = "Jack Walker";
+    private static final String VALID_TITLE = "Meeting 1";
+    private static final String VALID_DATETIME = "29/02/2023 12:00";
+    private static final String VALID_LOCATION = "Singapore NUS";
+    private static final String VALID_DESCRIPTION = "Meeting with Jack";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
@@ -58,7 +71,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseName_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseName((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseName(null));
     }
 
     @Test
@@ -80,8 +93,31 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseNames_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseNames(null));
+    }
+
+    @Test
+    public void parseNames_collectionWithInvalidNames_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseNames(Arrays.asList(VALID_NAME, INVALID_NAME)));
+    }
+
+    @Test
+    public void parseNames_emptyCollection_returnsEmptySet() throws Exception {
+        assertTrue(ParserUtil.parseNames(Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    public void parseNames_collectionWithValidNames_returnsNameSet() throws Exception {
+        Set<Name> actualNameSet = ParserUtil.parseNames(Arrays.asList(VALID_NAME, VALID_NAME_2));
+        Set<Name> expectedNameSet = new HashSet<>(Arrays.asList(new Name(VALID_NAME), new Name(VALID_NAME_2)));
+
+        assertEquals(expectedNameSet, actualNameSet);
+    }
+
+    @Test
     public void parsePhone_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parsePhone((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parsePhone(null));
     }
 
     @Test
@@ -104,7 +140,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseAddress_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseAddress((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseAddress( null));
     }
 
     @Test
@@ -127,7 +163,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseEmail_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail( null));
     }
 
     @Test
@@ -189,8 +225,100 @@ public class ParserUtilTest {
     @Test
     public void parseTags_collectionWithValidTags_returnsTagSet() throws Exception {
         Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, VALID_TAG_2));
-        Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
+        Set<Tag> expectedTagSet = new HashSet<>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseTitle_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseTitle(null));
+    }
+
+    @Test
+    public void parseTitle_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTitle(INVALID_TITLE));
+    }
+
+    @Test
+    public void parseTitle_validValueWithoutWhitespace_returnsTitle() throws Exception {
+        Title expectedTitle = new Title(VALID_TITLE);
+        assertEquals(expectedTitle, ParserUtil.parseTitle(VALID_TITLE));
+    }
+
+    @Test
+    public void parseTitle_validValueWithWhitespace_returnsTrimmedTitle() throws Exception {
+        String titleWithWhitespace = WHITESPACE + VALID_TITLE + WHITESPACE;
+        Title expectedTitle = new Title(VALID_TITLE);
+        assertEquals(expectedTitle, ParserUtil.parseTitle(titleWithWhitespace));
+    }
+
+    @Test
+    public void ParseDateTime_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDateTime(null));
+    }
+
+    @Test
+    public void ParseDateTime_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDateTime(INVALID_DATETIME));
+    }
+
+    @Test
+    public void ParseDateTime_validValueWithoutWhitespace_returnsDateTime() throws Exception {
+        DateTime expectedDateTime = new DateTime(VALID_DATETIME);
+        assertEquals(expectedDateTime, ParserUtil.parseDateTime(VALID_DATETIME));
+    }
+
+    @Test
+    public void ParseDateTime_validValueWithWhitespace_returnsTrimmedDateTime() throws Exception {
+        String dateTimeWithWhitespace = WHITESPACE + VALID_DATETIME + WHITESPACE;
+        DateTime expectedDateTime = new DateTime(VALID_DATETIME);
+        assertEquals(expectedDateTime, ParserUtil.parseDateTime(dateTimeWithWhitespace));
+    }
+
+    @Test
+    public void ParseLocation_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseLocation(null));
+    }
+
+    @Test
+    public void ParseLocation_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseLocation(INVALID_LOCATION));
+    }
+
+    @Test
+    public void ParseLocation_validValueWithoutWhitespace_returnsLocation() throws Exception {
+        Location expectedLocation = new Location(VALID_LOCATION);
+        assertEquals(expectedLocation, ParserUtil.parseLocation(VALID_LOCATION));
+    }
+
+    @Test
+    public void ParseLocation_validValueWithWhitespace_returnsTrimmedLocation() throws Exception {
+        String locationWithWhitespace = WHITESPACE + VALID_LOCATION + WHITESPACE;
+        Location expectedLocation = new Location(VALID_LOCATION);
+        assertEquals(expectedLocation, ParserUtil.parseLocation(locationWithWhitespace));
+    }
+
+    @Test
+    public void ParseDescription_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDescription(null));
+    }
+
+    @Test
+    public void ParseDescription_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDescription(INVALID_DESCRIPTION));
+    }
+
+    @Test
+    public void ParseDescription_validValueWithoutWhitespace_returnsDescription() throws Exception {
+        Description expectedDescription = new Description(VALID_DESCRIPTION);
+        assertEquals(expectedDescription, ParserUtil.parseDescription(VALID_DESCRIPTION));
+    }
+
+    @Test
+    public void ParseDescription_validValueWithWhitespace_returnsTrimmedDescription() throws Exception {
+        String descriptionWithWhitespace = WHITESPACE + VALID_DESCRIPTION + WHITESPACE;
+        Description expectedDescription = new Description(VALID_DESCRIPTION);
+        assertEquals(expectedDescription, ParserUtil.parseDescription(descriptionWithWhitespace));
     }
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -1,26 +1,33 @@
 package seedu.address.model;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import org.junit.jupiter.api.Test;
-import seedu.address.model.meeting.Meeting;
-import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
-import seedu.address.testutil.MeetingBuilder;
-import seedu.address.testutil.PersonBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_DESCRIPTION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_LOCATION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalAddressBooks.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalMeetings.MEETING_A;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalAddressBooks.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalMeetings.MEETING_A;
-import static seedu.address.testutil.TypicalPersons.ALICE;
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.testutil.MeetingBuilder;
+import seedu.address.testutil.PersonBuilder;
 
 public class AddressBookTest {
 
@@ -47,7 +54,7 @@ public class AddressBookTest {
     public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {
         // Two persons with the same identity fields
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+            .build();
         List<Person> newPersons = Arrays.asList(ALICE, editedAlice);
         AddressBookStub newData = new AddressBookStub(newPersons, Collections.singletonList(MEETING_A));
 
@@ -58,7 +65,7 @@ public class AddressBookTest {
     public void resetData_withDuplicateMeetings_throwsDuplicateMeetingException() {
         // Two meetings with the same identity fields
         Meeting editedMeetingA = new MeetingBuilder(MEETING_A).withLocation(VALID_MEETING_LOCATION)
-                .withDescription(VALID_MEETING_DESCRIPTION).build();
+            .withDescription(VALID_MEETING_DESCRIPTION).build();
         List<Meeting> newMeetings = Arrays.asList(MEETING_A, editedMeetingA);
         AddressBookStub newData = new AddressBookStub(Collections.singletonList(ALICE), newMeetings);
 
@@ -117,7 +124,7 @@ public class AddressBookTest {
     public void hasPerson_personWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+            .build();
         assertTrue(addressBook.hasPerson(editedAlice));
     }
 
@@ -125,7 +132,7 @@ public class AddressBookTest {
     public void hasMeeting_meetingWithSameIdentityFieldsInAddressBook_returnsTrue() {
         addressBook.addMeeting(MEETING_A);
         Meeting editedMeeting = new MeetingBuilder(MEETING_A).withLocation(VALID_MEETING_LOCATION)
-                .withDescription(VALID_MEETING_DESCRIPTION).build();
+            .withDescription(VALID_MEETING_DESCRIPTION).build();
         assertTrue(addressBook.hasMeeting(editedMeeting));
     }
 
@@ -138,7 +145,6 @@ public class AddressBookTest {
     public void getMeetingList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getMeetingList().remove(0));
     }
-
 
 
     /**

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -1,32 +1,26 @@
 package seedu.address.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_DESCRIPTION;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_LOCATION;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalAddressBooks.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalMeetings.MEETING_A;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import org.junit.jupiter.api.Test;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.MeetingBuilder;
 import seedu.address.testutil.PersonBuilder;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalAddressBooks.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalMeetings.MEETING_A;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 
 public class AddressBookTest {
 
@@ -82,6 +76,22 @@ public class AddressBookTest {
     }
 
     @Test
+    public void getPersonByName_nullName_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.getPersonByName(null));
+    }
+
+    @Test
+    public void getPersonByName_personNotInAddressBook_returnsNull() {
+        assertNull(addressBook.getPersonByName(ALICE.getName()));
+    }
+
+    @Test
+    public void getPersonByName_personInAddressBook_returnsPerson() {
+        addressBook.addPerson(ALICE);
+        assertEquals(ALICE, addressBook.getPersonByName(ALICE.getName()));
+    }
+
+    @Test
     public void hasPerson_personNotInAddressBook_returnsFalse() {
         assertFalse(addressBook.hasPerson(ALICE));
     }
@@ -128,6 +138,8 @@ public class AddressBookTest {
     public void getMeetingList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getMeetingList().remove(0));
     }
+
+
 
     /**
      * A stub ReadOnlyAddressBook whose persons/meetings list can violate interface constraints.

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -1,20 +1,24 @@
 package seedu.address.model;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.testutil.AddressBookBuilder;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalMeetings.MEETING_A;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -1,22 +1,20 @@
 package seedu.address.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.BENSON;
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.testutil.AddressBookBuilder;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import org.junit.jupiter.api.Test;
-
-import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.testutil.AddressBookBuilder;
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalMeetings.MEETING_A;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 
 public class ModelManagerTest {
 
@@ -89,8 +87,51 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getPersonByName_nullName_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.getPersonByName(null));
+    }
+
+    @Test
+    public void getPersonByName_personNotInAddressBook_returnsNull() {
+        assertNull(modelManager.getPersonByName(ALICE.getName()));
+    }
+
+    @Test
+    public void getPersonByName_personInAddressBook_returnsPerson() {
+        modelManager.addPerson(ALICE);
+        assertEquals(ALICE, modelManager.getPersonByName(ALICE.getName()));
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+    }
+
+    @Test
+    public void addMeeting_nullMeeting_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.addMeeting(null));
+    }
+
+    @Test
+    public void addMeeting_meetingInAddressBook_returnsTrue() {
+        modelManager.addMeeting(MEETING_A);
+        assertTrue(modelManager.hasMeeting(MEETING_A));
+    }
+
+    @Test
+    public void hasMeeting_nullMeeting_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasMeeting(null));
+    }
+
+    @Test
+    public void hasMeeting_meetingNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasMeeting(MEETING_A));
+    }
+
+    @Test
+    public void hasMeeting_meetingInAddressBook_returnsTrue() {
+        modelManager.addMeeting(MEETING_A);
+        assertTrue(modelManager.hasMeeting(MEETING_A));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -1,20 +1,24 @@
 package seedu.address.model.person;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
-import seedu.address.model.person.exceptions.PersonNotFoundException;
-import seedu.address.testutil.PersonBuilder;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.testutil.PersonBuilder;
 
 public class UniquePersonListTest {
 
@@ -40,7 +44,7 @@ public class UniquePersonListTest {
     public void contains_personWithSameIdentityFieldsInList_returnsTrue() {
         uniquePersonList.add(ALICE);
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+            .build();
         assertTrue(uniquePersonList.contains(editedAlice));
     }
 
@@ -83,7 +87,7 @@ public class UniquePersonListTest {
     public void setPerson_editedPersonHasSameIdentity_success() {
         uniquePersonList.add(ALICE);
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+            .build();
         uniquePersonList.setPerson(ALICE, editedAlice);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();
         expectedUniquePersonList.add(editedAlice);

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -1,23 +1,20 @@
 package seedu.address.model.person;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.BOB;
+import org.junit.jupiter.api.Test;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.testutil.PersonBuilder;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-
-import seedu.address.model.person.exceptions.DuplicatePersonException;
-import seedu.address.model.person.exceptions.PersonNotFoundException;
-import seedu.address.testutil.PersonBuilder;
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
 public class UniquePersonListTest {
 
@@ -107,6 +104,23 @@ public class UniquePersonListTest {
         uniquePersonList.add(ALICE);
         uniquePersonList.add(BOB);
         assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setPerson(ALICE, BOB));
+    }
+
+    @Test
+    public void getPersonByName_nullName_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniquePersonList.getPersonByName(null));
+    }
+
+    @Test
+    public void getPersonByName_personNotInList_throwsPersonNotFoundException() {
+        assertNull(uniquePersonList.getPersonByName(ALICE.getName()));
+    }
+
+    @Test
+    public void getPersonByName_personInList_returnsPerson() {
+        uniquePersonList.add(ALICE);
+        Person person = uniquePersonList.getPersonByName(ALICE.getName());
+        assertEquals(ALICE, person);
     }
 
     @Test


### PR DESCRIPTION
This PR implements `AddMeetingCommand` in `QuickContacts`(#1).

## Additions
### Classes
- `AddMeetingCommand` : The command class to add meeting dc3b627ee2fa52ef2f6498db8fd8ff8bb5d30ebb
- `AddMeetingCommandParser`: The parser to parse add meeting command ad86e52d056b541e326d836ce3ac173433069e17
- Relevant test classes for the above 2 classes.

### Methods/Variables
- New prefixes, look at eb2eb7cba511f3fc52ca697ec469b5c9c11835a1 for more info
- New parse functions for the Meeting classes b381acc1d7b0c05434892b7374a24670682f134c
- New method to get a Person by Name 787bd96a391011042137859d4dacaade0a3b79ad
- Updated Model and ModelManager with methods implemented in classes extending them f3339c534eb6bb1e7e53885fa4ec65a92a87ecef 57eabdd5fe4b45ee94f251abb700ee186bde0a53
- Add more utility constants for testing of Meeting related methods 744659dbf3e62d62eeecd61af6c737db96f649e9

### Minor Fixes
- Update `AddCommandTest` e0253dd258162c8408a9ff9318c0fbaea927304d to support changes made in Model f3339c534eb6bb1e7e53885fa4ec65a92a87ecef


### Command Usage (As of this PR)
````
addm m/ _MeetingTitle_ d/ _dd/MM/YYYY HH:mm_ p/ _PERSON1_ p/ _PERSON2_ l/ _LOCATION_ des/ _DESCRIPTION_ 
````
#### Constraints
- Minimum 1 person, no maximum. Only adds person if they are already present in your contacts. All fields **compulsory**.