### PR TITLE
Populate sample `Meeting` data on first launch

### DIFF
--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -6,6 +6,11 @@ import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.meeting.DateTime;
+import seedu.address.model.meeting.Description;
+import seedu.address.model.meeting.Location;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.Title;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -17,11 +22,16 @@ import seedu.address.model.tag.Tag;
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
+    /**
+     * {@code Person} that are also attendees of meetings.
+     */
+    private static final Person ALEX = new Person(new Name("Alex Yeoh"), new Phone("87438807"),
+            new Email("alexyeoh@example.com"), new Address("Blk 30 Geylang Street 29, #06-40"),
+            getTagSet("friends"));
+
     public static Person[] getSamplePersons() {
         return new Person[] {
-            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
+            ALEX,
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                 getTagSet("colleagues", "friends")),
@@ -40,11 +50,23 @@ public class SampleDataUtil {
         };
     }
 
+    public static Meeting[] getSampleMeetingss() {
+        return new Meeting[] {
+            new Meeting(new Title("Lunch with Alex"), new DateTime("03/03/2023 15:00"), getAttendeeSet(ALEX),
+                    new Location("The Deck"), new Description("Catch-up"))
+        };
+    }
+
     public static ReadOnlyAddressBook getSampleAddressBook() {
         AddressBook sampleAb = new AddressBook();
         for (Person samplePerson : getSamplePersons()) {
             sampleAb.addPerson(samplePerson);
         }
+
+        for (Meeting sampleMeeting : getSampleMeetingss()) {
+            sampleAb.addMeeting(sampleMeeting);
+        }
+
         return sampleAb;
     }
 


### PR DESCRIPTION
This PR implements the population of sample `Meeting` data when a new user first launches `QuickContacts`