### PR TITLE
Implement shortcut to traverse commands

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ViewMeetingsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.command.CommandHistory;
 
 /**
  * Parses user input.
@@ -38,6 +39,7 @@ public class AddressBookParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public Command parseCommand(String userInput) throws ParseException {
+        CommandHistory.push(userInput);
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/model/command/CommandHistory.java
+++ b/src/main/java/seedu/address/model/command/CommandHistory.java
@@ -1,0 +1,49 @@
+package seedu.address.model.command;
+
+import java.util.LinkedList;
+
+import seedu.address.model.command.exceptions.OutOfBoundsCommandHistoryException;
+
+/**
+ *
+ */
+public class CommandHistory {
+    /**
+     * The maximum number of commands kept in memory.
+     */
+    public static final int MAXIMUM = 30;
+
+    private static final LinkedList<String> commands = new LinkedList<>();
+    private static int index = -1;
+
+    public static void push(String input) {
+        if (commands.size() >= MAXIMUM) {
+            commands.removeFirst();
+        }
+
+        commands.add(input);
+        index = commands.size() - 1;
+    }
+
+    public static void setLast() {
+        index = commands.size();
+    }
+
+    public static String prev() throws OutOfBoundsCommandHistoryException {
+        if (!commands.isEmpty() && index > 0) {
+            index--;
+            return commands.get(index);
+        }
+
+        throw new OutOfBoundsCommandHistoryException();
+    }
+
+    public static String next() throws OutOfBoundsCommandHistoryException {
+        if (index < commands.size() - 1) {
+            index++;
+            return commands.get(index);
+        }
+
+        throw new OutOfBoundsCommandHistoryException();
+    }
+}

--- a/src/main/java/seedu/address/model/command/CommandHistory.java
+++ b/src/main/java/seedu/address/model/command/CommandHistory.java
@@ -5,7 +5,8 @@ import java.util.LinkedList;
 import seedu.address.model.command.exceptions.OutOfBoundsCommandHistoryException;
 
 /**
- *
+ * Represents a CommandHistory that consists of all the previously executed commands,
+ * regardless of their validity.
  */
 public class CommandHistory {
     /**
@@ -16,6 +17,10 @@ public class CommandHistory {
     private static final LinkedList<String> commands = new LinkedList<>();
     private static int index = -1;
 
+    /**
+     * Adds a command to be the last one in the {@code CommandHistory}.
+     * @param input The command input.
+     */
     public static void push(String input) {
         if (commands.size() >= MAXIMUM) {
             commands.removeFirst();
@@ -25,12 +30,29 @@ public class CommandHistory {
         index = commands.size() - 1;
     }
 
+    /**
+     * Sets the pointer such that {@code CommandHistory.prev()} will return the last command.
+     */
     public static void setLast() {
         index = commands.size();
     }
 
+    private static boolean hasPrev() {
+        return !commands.isEmpty() && index > 0;
+    }
+
+    private static boolean hasNext() {
+        return index < commands.size() - 1;
+    }
+
+    /**
+     * Retrieves the previous command in the {@code CommandHistory}.
+     *
+     * @return The previous command input.
+     * @throws OutOfBoundsCommandHistoryException If there are no commands before the current one.
+     */
     public static String prev() throws OutOfBoundsCommandHistoryException {
-        if (!commands.isEmpty() && index > 0) {
+        if (hasPrev()) {
             index--;
             return commands.get(index);
         }
@@ -38,8 +60,14 @@ public class CommandHistory {
         throw new OutOfBoundsCommandHistoryException();
     }
 
+    /**
+     * Retrieves the next command in the {@code CommandHistory}.
+     *
+     * @return The next command input.
+     * @throws OutOfBoundsCommandHistoryException If there are no commands after the current one.
+     */
     public static String next() throws OutOfBoundsCommandHistoryException {
-        if (index < commands.size() - 1) {
+        if (hasNext()) {
             index++;
             return commands.get(index);
         }

--- a/src/main/java/seedu/address/model/command/CommandHistory.java
+++ b/src/main/java/seedu/address/model/command/CommandHistory.java
@@ -74,4 +74,12 @@ public class CommandHistory {
 
         throw new OutOfBoundsCommandHistoryException();
     }
+
+    /**
+     * Clears {@code CommandHistory}
+     */
+    public static void clear() {
+        commands.clear();
+        index = -1;
+    }
 }

--- a/src/main/java/seedu/address/model/command/exceptions/OutOfBoundsCommandHistoryException.java
+++ b/src/main/java/seedu/address/model/command/exceptions/OutOfBoundsCommandHistoryException.java
@@ -1,0 +1,8 @@
+package seedu.address.model.command.exceptions;
+
+/**
+ * Signals that the operation is unable to retrieve any commands from the history
+ * as the index is out of bounds.
+ */
+public class OutOfBoundsCommandHistoryException extends RuntimeException {
+}

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,12 +1,17 @@
 package seedu.address.ui;
 
 import javafx.collections.ObservableList;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.command.CommandHistory;
+import seedu.address.model.command.exceptions.OutOfBoundsCommandHistoryException;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -29,6 +34,7 @@ public class CommandBox extends UiPart<Region> {
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.setOnKeyPressed(new KeyPressedHandler());
     }
 
     /**
@@ -80,6 +86,40 @@ public class CommandBox extends UiPart<Region> {
          * @see seedu.address.logic.Logic#execute(String)
          */
         CommandResult execute(String commandText) throws CommandException, ParseException;
+    }
+
+    public class KeyPressedHandler implements EventHandler<KeyEvent> {
+        @Override
+        public void handle(KeyEvent event) {
+            KeyCode key = event.getCode();
+
+            if (key.equals(KeyCode.UP)) {
+                if (commandTextField.getText().equals("")) {
+                    CommandHistory.setLast();
+                }
+
+                try {
+                    commandTextField.setStyle("-fx-display-caret: false;");
+                    commandTextField.setText(CommandHistory.prev());
+                } catch (OutOfBoundsCommandHistoryException e) {
+                    // Nothing to do
+                } finally {
+                    commandTextField.end();
+                    commandTextField.setStyle("-fx-display-caret: true;");
+
+                }
+            }
+
+            if (key.equals(KeyCode.DOWN)) {
+                try {
+                    commandTextField.setText(CommandHistory.next());
+                } catch (OutOfBoundsCommandHistoryException e) {
+                    commandTextField.setText("");
+                } finally {
+                    commandTextField.end();
+                }
+            }
+        }
     }
 
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -88,6 +88,9 @@ public class CommandBox extends UiPart<Region> {
         CommandResult execute(String commandText) throws CommandException, ParseException;
     }
 
+    /**
+     * Represents the handler for {@code KeyCode.UP} and {@code KeyCode.DOWN} key-presses.
+     */
     public class KeyPressedHandler implements EventHandler<KeyEvent> {
         @Override
         public void handle(KeyEvent event) {

--- a/src/test/java/seedu/address/model/command/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/model/command/CommandHistoryTest.java
@@ -3,29 +3,28 @@ package seedu.address.model.command;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
 import seedu.address.model.command.exceptions.OutOfBoundsCommandHistoryException;
 
-@TestMethodOrder(OrderAnnotation.class)
 public class CommandHistoryTest {
+    @BeforeEach
+    public void setUp() {
+        CommandHistory.clear();
+    }
+
     @Test
-    @Order(1)
     public void traversePrevEmptyHistory_throwsOutOfBoundsCommandHistoryException() {
         assertThrows(OutOfBoundsCommandHistoryException.class, CommandHistory::prev);
     }
 
     @Test
-    @Order(2)
     public void traverseNextEmptyHistory_throwsOutOfBoundsCommandHistoryException() {
         assertThrows(OutOfBoundsCommandHistoryException.class, CommandHistory::next);
     }
 
     @Test
-    @Order(3)
     public void moreThanMaximumNumberOfCommands_overwriteEarliestCommand() {
         String expected = "expectedCommand";
         CommandHistory.push("dummyCommand");
@@ -42,5 +41,6 @@ public class CommandHistoryTest {
         }
 
         assertEquals(CommandHistory.prev(), expected);
+
     }
 }

--- a/src/test/java/seedu/address/model/command/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/model/command/CommandHistoryTest.java
@@ -1,0 +1,46 @@
+package seedu.address.model.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import seedu.address.model.command.exceptions.OutOfBoundsCommandHistoryException;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class CommandHistoryTest {
+    @Test
+    @Order(1)
+    public void traversePrevEmptyHistory_throwsOutOfBoundsCommandHistoryException() {
+        assertThrows(OutOfBoundsCommandHistoryException.class, CommandHistory::prev);
+    }
+
+    @Test
+    @Order(2)
+    public void traverseNextEmptyHistory_throwsOutOfBoundsCommandHistoryException() {
+        assertThrows(OutOfBoundsCommandHistoryException.class, CommandHistory::next);
+    }
+
+    @Test
+    @Order(3)
+    public void moreThanMaximumNumberOfCommands_overwriteEarliestCommand() {
+        String expected = "expectedCommand";
+        CommandHistory.push("dummyCommand");
+        CommandHistory.push(expected);
+
+        for (int i = 0; i < CommandHistory.MAXIMUM - 2; ++i) {
+            CommandHistory.push(String.valueOf(i));
+        }
+
+        CommandHistory.push("testcommand");
+
+        for (int i = 0; i < CommandHistory.MAXIMUM - 2; ++i) {
+            CommandHistory.prev();
+        }
+
+        assertEquals(CommandHistory.prev(), expected);
+    }
+}


### PR DESCRIPTION
This PR implements the feature for users to simply press the `UP` and `DOWN` arrowkeys to traverse between the previous command and subsequent commands in the history.

resolves #58