### PR TITLE
Varying input formats for `DateTime`

### DIFF
--- a/src/main/java/seedu/address/model/meeting/DateTime.java
+++ b/src/main/java/seedu/address/model/meeting/DateTime.java
@@ -5,10 +5,15 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import java.util.Objects;
+
+import seedu.address.model.meeting.exceptions.InvalidDateTimeFormatException;
 
 /**
  * Represents a Meetings's date/time in the address book.
@@ -35,7 +40,19 @@ public class DateTime {
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{ASCII} ]*";
 
-    private final LocalDateTime meetingDateTime;
+    private static final String[] DATE_SEPARATORS = {"/", "", ".", "-"};
+    private static final String[] TIME_SEPARATORS = {":", "", "."};
+    private static final String SEPARATOR_PLACEHOLDER = "{sep}";
+    private static final String DDMMYYYY_TEMPLATE = "dd" + SEPARATOR_PLACEHOLDER + "MM"
+            + SEPARATOR_PLACEHOLDER + "yyyy";
+    private static final String DDMMYY_TEMPLATE = "dd" + SEPARATOR_PLACEHOLDER + "MM"
+            + SEPARATOR_PLACEHOLDER + "yy";
+    private static final String DDMM_TEMPLATE = "dd" + SEPARATOR_PLACEHOLDER + "MM";
+    private static final String HHMM_TEMPLATE = "HH" + SEPARATOR_PLACEHOLDER + "mm";
+    private static final String HHMM_AM_PM_TEMPLATE = "h" + SEPARATOR_PLACEHOLDER + "mma";
+
+    private final LocalDate meetingDate;
+    private final LocalTime meetingTime;
 
     /**
      * This is used only for inputs that include specific durations.
@@ -52,8 +69,19 @@ public class DateTime {
     public DateTime(String dateTime) {
         requireNonNull(dateTime);
         checkArgument(isValidDateTime(dateTime), MESSAGE_CONSTRAINTS);
-        meetingDateTime = LocalDateTime.parse(dateTime,
-                DateTimeFormatter.ofPattern(String.format("%s %s", DATE_FORMAT, TIME_FORMAT)));
+
+        String[] dtSplit = dateTime.split(" ");
+
+        String datePortion = dtSplit[0];
+        meetingDate = stringToLocalDate(datePortion);
+
+        if (dtSplit.length == 2) {
+            String timePortion = dtSplit[1];
+            meetingTime = stringToLocalTime(timePortion);
+        } else {
+            meetingTime = LocalTime.MIN;
+        }
+
         meetingDuration = Duration.ZERO;
     }
 
@@ -68,23 +96,72 @@ public class DateTime {
         checkArgument(isValidDateTime(startDateTime), MESSAGE_CONSTRAINTS);
         checkArgument(isValidDateTime(endDateTime), MESSAGE_CONSTRAINTS);
 
-        meetingDateTime = stringToLocalDateTime(startDateTime);
-        LocalDateTime end = stringToLocalDateTime(endDateTime);
+        String[] startDtSplit = startDateTime.split(" ");
+        String[] endDtSplit = endDateTime.split(" ");
 
-        checkArgument(isValidDuration(meetingDateTime, end), MESSAGE_CONSTRAINTS);
+        String startDatePortion = startDtSplit[0];
+        String endDatePortion = endDtSplit[0];
+        meetingDate = stringToLocalDate(startDatePortion);
 
-        meetingDuration = Duration.between(meetingDateTime, end);
+        if (startDtSplit.length == 2 && endDtSplit.length == 2) {
+            String startTimePortion = startDtSplit[1];
+            String endTimePortion = endDtSplit[1];
+            meetingTime = stringToLocalTime(startTimePortion);
+
+            LocalDateTime startDT = LocalDateTime.of(meetingDate, meetingTime);
+            LocalDateTime endDT = LocalDateTime.of(stringToLocalDate(endDatePortion),
+                    stringToLocalTime(endTimePortion));
+
+            checkArgument(isValidDuration(startDT, endDT));
+            meetingDuration = Duration.between(startDT, endDT);
+        } else {
+            meetingTime = LocalTime.MIN;
+            meetingDuration = Duration.between(meetingDate, stringToLocalDate(endDatePortion));
+        }
     }
 
     public String getDateTime() {
-        return meetingDateTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT + " " + TIME_FORMAT));
+        if (!meetingTime.equals(LocalTime.MIN)) {
+            return meetingDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT))
+                    + " "
+                    + meetingTime.format(DateTimeFormatter.ofPattern(TIME_FORMAT));
+        }
+
+        return meetingDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT));
     }
 
     /**
      * Returns true if a given string is a valid date/time.
      */
     public static boolean isValidDateTime(String test) {
-        return test.matches(VALIDATION_REGEX) && !stringToLocalDateTime(test).equals(LocalDateTime.MIN);
+        String[] dtSplit = test.split(" ");
+
+        if (dtSplit.length > 2 || !test.matches(VALIDATION_REGEX)) {
+            return false;
+        }
+
+        String datePortion = dtSplit[0];
+        if (dtSplit.length == 1) {
+            return isValidDate(datePortion);
+        }
+
+        String timePortion = dtSplit[1];
+
+        return isValidDate(datePortion) && isValidTime(timePortion);
+    }
+
+    /**
+     * Returns true if a given string is a valid date.
+     */
+    private static boolean isValidDate(String test) {
+        return test.matches(VALIDATION_REGEX) && !stringToLocalDate(test).equals(LocalDate.MIN);
+    }
+
+    /**
+     * Returns true if a given string is a valid time.
+     */
+    private static boolean isValidTime(String test) {
+        return test.matches(VALIDATION_REGEX) && !stringToLocalTime(test).equals(LocalTime.MIN);
     }
 
     /**
@@ -95,42 +172,123 @@ public class DateTime {
                 && !Duration.between(startDateTime, endDateTime).isZero();
     }
 
-    private static LocalDateTime stringToLocalDateTime(String dateTime) {
+    private static LocalDate stringToLocalDate(String date) {
         try {
-            return LocalDateTime.parse(dateTime,
-                    DateTimeFormatter.ofPattern(String.format("%s %s", DATE_FORMAT, TIME_FORMAT)));
-        } catch (DateTimeParseException e) {
-            return LocalDateTime.MIN;
+            return parseDate(date, getDateFormat(date));
+        } catch (InvalidDateTimeFormatException e) {
+            return LocalDate.MIN;
         }
+    }
+
+    private static LocalTime stringToLocalTime(String time) {
+        try {
+            return parseTime(time, getTimeFormat(time));
+        } catch (InvalidDateTimeFormatException e) {
+            return LocalTime.MIN;
+        }
+    }
+
+    private static LocalDate parseDate(String date, String pattern) {
+        try {
+            return LocalDate.parse(date, DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH));
+        } catch (DateTimeParseException e) {
+            return LocalDate.MIN;
+        }
+    }
+
+    private static LocalTime parseTime(String time, String pattern) {
+        try {
+            return LocalTime.parse(time, DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH));
+        } catch (DateTimeParseException e) {
+            System.out.println(time + " " + pattern);
+            return LocalTime.MIN;
+        }
+    }
+
+    private static String getDateFormat(String date) throws InvalidDateTimeFormatException {
+        String dateFormat = "";
+        for (String separator : DATE_SEPARATORS) {
+            String ddmmyyyyPattern = patternForSeparator(DDMMYYYY_TEMPLATE, separator);
+            String ddmmyyPattern = patternForSeparator(DDMMYY_TEMPLATE, separator);
+            String ddmmPattern = patternForSeparator(DDMM_TEMPLATE, separator);
+
+            if (!parseDate(date, ddmmyyyyPattern).isEqual(LocalDate.MIN)) {
+                dateFormat = ddmmyyyyPattern;
+            }
+
+            if (!parseDate(date, ddmmyyPattern).isEqual(LocalDate.MIN)) {
+                dateFormat = ddmmyyPattern;
+            }
+
+            if (!parseDate(date, ddmmPattern).isEqual(LocalDate.MIN)) {
+                dateFormat = ddmmPattern;
+            }
+        }
+
+        if (dateFormat.isEmpty()) {
+            throw new InvalidDateTimeFormatException();
+        }
+
+        return dateFormat;
+    }
+
+    private static String getTimeFormat(String time) throws InvalidDateTimeFormatException {
+        String timeFormat = "";
+        for (String separator : TIME_SEPARATORS) {
+            String hhmmPattern = patternForSeparator(HHMM_TEMPLATE, separator);
+            String hhmmampmPattern = patternForSeparator(HHMM_AM_PM_TEMPLATE, separator);
+
+            if (!parseTime(time, hhmmPattern).equals(LocalTime.MIN)) {
+                timeFormat = hhmmPattern;
+            }
+
+            if (!parseTime(time, hhmmampmPattern).equals(LocalTime.MIN)) {
+                System.out.println("testt" + " " + hhmmampmPattern);
+                timeFormat = hhmmampmPattern;
+            }
+        }
+
+        if (timeFormat.isEmpty()) {
+            throw new InvalidDateTimeFormatException();
+        }
+
+        return timeFormat;
+    }
+
+    private static String patternForSeparator(String template, String sep) {
+        return template.replace(SEPARATOR_PLACEHOLDER, sep);
     }
 
     @Override
     public String toString() {
         String end = meetingDuration != null && !meetingDuration.isZero()
-                ? meetingDateTime.plus(meetingDuration).format(
+                ? LocalDateTime.of(meetingDate, meetingTime).plus(meetingDuration).format(
                         DateTimeFormatter.ofPattern(DATE_FORMAT + " " + TIME_FORMAT))
                 : "";
 
         if (!end.isEmpty()) {
-            return meetingDateTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT + " " + TIME_FORMAT))
+            return meetingDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT))
+                    + " "
+                    + meetingTime.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                     + " to "
                     + end;
         }
 
-        return meetingDateTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT + " " + TIME_FORMAT));
+        return getDateTime();
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DateTime // instanceof handles nulls
-                && meetingDateTime.equals(((DateTime) other).meetingDateTime) // state check
+                && meetingDate.equals(((DateTime) other).meetingDate) // state check
+                && meetingTime.equals(((DateTime) other).meetingTime) // state check
                 && meetingDuration.equals(((DateTime) other).meetingDuration)); // state check
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(meetingDateTime, meetingDuration);
+        return Objects.hash(meetingDate, meetingTime, meetingDuration);
     }
 }

--- a/src/main/java/seedu/address/model/meeting/DateTime.java
+++ b/src/main/java/seedu/address/model/meeting/DateTime.java
@@ -53,6 +53,11 @@ public class DateTime {
     private static final String HHMM_AM_PM_TEMPLATE = "h" + SEPARATOR_PLACEHOLDER + "mma";
 
     private final LocalDate meetingDate;
+
+    /**
+     * If meetingTime is not specified in the input, {@code meetingTime} will
+     * be set to {@code LocalTime.MIN}.
+     */
     private final LocalTime meetingTime;
 
     /**
@@ -121,6 +126,10 @@ public class DateTime {
         }
     }
 
+    /**
+     * Returns a {@code string} representation of the Date and Time (if exists) stored
+     * in this class.
+     */
     public String getDateTime() {
         if (!meetingTime.equals(LocalTime.MIN)) {
             return meetingDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT))
@@ -152,6 +161,14 @@ public class DateTime {
     }
 
     /**
+     * Returns true if a given string is a valid date/time.
+     */
+    public static boolean isValidDuration(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return !Duration.between(startDateTime, endDateTime).isNegative()
+                && !Duration.between(startDateTime, endDateTime).isZero();
+    }
+
+    /**
      * Returns true if a given string is a valid date.
      */
     private static boolean isValidDate(String test) {
@@ -163,14 +180,6 @@ public class DateTime {
      */
     private static boolean isValidTime(String test) {
         return test.matches(VALIDATION_REGEX) && !stringToLocalTime(test).equals(LocalTime.MIN);
-    }
-
-    /**
-     * Returns true if a given string is a valid date/time.
-     */
-    public static boolean isValidDuration(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return !Duration.between(startDateTime, endDateTime).isNegative()
-                && !Duration.between(startDateTime, endDateTime).isZero();
     }
 
     private static LocalDate stringToLocalDate(String date) {
@@ -256,7 +265,6 @@ public class DateTime {
             }
 
             if (!parseTime(time, hhmmampmPattern).equals(LocalTime.MIN)) {
-                System.out.println("testt" + " " + hhmmampmPattern);
                 timeFormat = hhmmampmPattern;
             }
         }

--- a/src/main/java/seedu/address/model/meeting/DateTime.java
+++ b/src/main/java/seedu/address/model/meeting/DateTime.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Year;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
@@ -190,8 +191,21 @@ public class DateTime {
 
     private static LocalDate parseDate(String date, String pattern) {
         try {
-            return LocalDate.parse(date, DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH));
-        } catch (DateTimeParseException e) {
+            if (!pattern.equals("ddMM")) {
+                return LocalDate.parse(date, DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH));
+            }
+
+            if (date.length() != 4 && date.length() != 5) {
+                throw new InvalidDateTimeFormatException();
+            }
+
+            String newDate = date + Year.now();
+            if (date.length() == 5) {
+                newDate = date + date.charAt(2) + Year.now();
+            }
+
+            return LocalDate.parse(newDate, DateTimeFormatter.ofPattern(getDateFormat(newDate), Locale.ENGLISH));
+        } catch (DateTimeParseException | InvalidDateTimeFormatException e) {
             return LocalDate.MIN;
         }
     }
@@ -200,7 +214,6 @@ public class DateTime {
         try {
             return LocalTime.parse(time, DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH));
         } catch (DateTimeParseException e) {
-            System.out.println(time + " " + pattern);
             return LocalTime.MIN;
         }
     }

--- a/src/main/java/seedu/address/model/meeting/DateTime.java
+++ b/src/main/java/seedu/address/model/meeting/DateTime.java
@@ -56,7 +56,7 @@ public class DateTime {
 
     /**
      * If meetingTime is not specified in the input, {@code meetingTime} will
-     * be set to {@code LocalTime.MIN}.
+     * be set to {@code LocalTime.MAX}.
      */
     private final LocalTime meetingTime;
 
@@ -85,7 +85,7 @@ public class DateTime {
             String timePortion = dtSplit[1];
             meetingTime = stringToLocalTime(timePortion);
         } else {
-            meetingTime = LocalTime.MIN;
+            meetingTime = LocalTime.MAX;
         }
 
         meetingDuration = Duration.ZERO;
@@ -121,7 +121,7 @@ public class DateTime {
             checkArgument(isValidDuration(startDT, endDT));
             meetingDuration = Duration.between(startDT, endDT);
         } else {
-            meetingTime = LocalTime.MIN;
+            meetingTime = LocalTime.MAX;
             meetingDuration = Duration.between(meetingDate, stringToLocalDate(endDatePortion));
         }
     }
@@ -131,7 +131,7 @@ public class DateTime {
      * in this class.
      */
     public String getDateTime() {
-        if (!meetingTime.equals(LocalTime.MIN)) {
+        if (meetingTime != LocalTime.MAX) {
             return meetingDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT))
                     + " "
                     + meetingTime.format(DateTimeFormatter.ofPattern(TIME_FORMAT));
@@ -172,21 +172,21 @@ public class DateTime {
      * Returns true if a given string is a valid date.
      */
     private static boolean isValidDate(String test) {
-        return test.matches(VALIDATION_REGEX) && !stringToLocalDate(test).equals(LocalDate.MIN);
+        return test.matches(VALIDATION_REGEX) && stringToLocalDate(test) != LocalDate.MAX;
     }
 
     /**
      * Returns true if a given string is a valid time.
      */
     private static boolean isValidTime(String test) {
-        return test.matches(VALIDATION_REGEX) && !stringToLocalTime(test).equals(LocalTime.MIN);
+        return test.matches(VALIDATION_REGEX) && stringToLocalTime(test) != LocalTime.MAX;
     }
 
     private static LocalDate stringToLocalDate(String date) {
         try {
             return parseDate(date, getDateFormat(date));
         } catch (InvalidDateTimeFormatException e) {
-            return LocalDate.MIN;
+            return LocalDate.MAX;
         }
     }
 
@@ -194,7 +194,7 @@ public class DateTime {
         try {
             return parseTime(time, getTimeFormat(time));
         } catch (InvalidDateTimeFormatException e) {
-            return LocalTime.MIN;
+            return LocalTime.MAX;
         }
     }
 
@@ -215,7 +215,7 @@ public class DateTime {
 
             return LocalDate.parse(newDate, DateTimeFormatter.ofPattern(getDateFormat(newDate), Locale.ENGLISH));
         } catch (DateTimeParseException | InvalidDateTimeFormatException e) {
-            return LocalDate.MIN;
+            return LocalDate.MAX;
         }
     }
 
@@ -223,7 +223,7 @@ public class DateTime {
         try {
             return LocalTime.parse(time, DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH));
         } catch (DateTimeParseException e) {
-            return LocalTime.MIN;
+            return LocalTime.MAX;
         }
     }
 
@@ -234,15 +234,15 @@ public class DateTime {
             String ddmmyyPattern = patternForSeparator(DDMMYY_TEMPLATE, separator);
             String ddmmPattern = patternForSeparator(DDMM_TEMPLATE, separator);
 
-            if (!parseDate(date, ddmmyyyyPattern).isEqual(LocalDate.MIN)) {
+            if (parseDate(date, ddmmyyyyPattern) != LocalDate.MAX) {
                 dateFormat = ddmmyyyyPattern;
             }
 
-            if (!parseDate(date, ddmmyyPattern).isEqual(LocalDate.MIN)) {
+            if (parseDate(date, ddmmyyPattern) != LocalDate.MAX) {
                 dateFormat = ddmmyyPattern;
             }
 
-            if (!parseDate(date, ddmmPattern).isEqual(LocalDate.MIN)) {
+            if (parseDate(date, ddmmPattern) != LocalDate.MAX) {
                 dateFormat = ddmmPattern;
             }
         }
@@ -260,11 +260,11 @@ public class DateTime {
             String hhmmPattern = patternForSeparator(HHMM_TEMPLATE, separator);
             String hhmmampmPattern = patternForSeparator(HHMM_AM_PM_TEMPLATE, separator);
 
-            if (!parseTime(time, hhmmPattern).equals(LocalTime.MIN)) {
+            if (parseTime(time, hhmmPattern) != LocalTime.MAX) {
                 timeFormat = hhmmPattern;
             }
 
-            if (!parseTime(time, hhmmampmPattern).equals(LocalTime.MIN)) {
+            if (parseTime(time, hhmmampmPattern) != LocalTime.MAX) {
                 timeFormat = hhmmampmPattern;
             }
         }

--- a/src/main/java/seedu/address/model/meeting/DateTime.java
+++ b/src/main/java/seedu/address/model/meeting/DateTime.java
@@ -280,6 +280,20 @@ public class DateTime {
         return template.replace(SEPARATOR_PLACEHOLDER, sep);
     }
 
+    /**
+     * Returns {@code LocalDateTime} representation of the DateTime stored.
+     * If time is not specified, it will default to 00:00 (12AM).
+     *
+     * @return {@code LocalDateTime} representation of the DateTime stored.
+     */
+    public LocalDateTime get() {
+        if (meetingTime == LocalTime.MAX) {
+            return LocalDateTime.of(meetingDate, LocalTime.of(0, 0));
+        }
+
+        return LocalDateTime.of(meetingDate, meetingTime);
+    }
+
     @Override
     public String toString() {
         String end = meetingDuration != null && !meetingDuration.isZero()

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -2,6 +2,7 @@ package seedu.address.model.meeting;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -22,6 +23,8 @@ public class Meeting {
     // Data fields
     private final Location location;
     private final Description description;
+
+    private boolean hasPassed = false;
 
     /**
      * Every field must be present and not null.
@@ -72,6 +75,14 @@ public class Meeting {
                 && otherMeeting.getTitle().equals(getTitle())
                 && otherMeeting.getDateTime().equals(getDateTime())
                 && otherMeeting.getAttendees().equals(getAttendees());
+    }
+
+    /**
+     * Returns true if {@code Meeting} has passed based on the current DateTime.
+     */
+    public boolean hasPassed() {
+        this.hasPassed = LocalDateTime.now().isAfter(dateTime.get());
+        return this.hasPassed;
     }
 
     /**

--- a/src/main/java/seedu/address/model/meeting/exceptions/InvalidDateTimeFormatException.java
+++ b/src/main/java/seedu/address/model/meeting/exceptions/InvalidDateTimeFormatException.java
@@ -1,0 +1,8 @@
+package seedu.address.model.meeting.exceptions;
+
+/**
+ * Signals that the operation is unable to convert a dateTime from its
+ * string representation to a specified format.
+ */
+public class InvalidDateTimeFormatException extends RuntimeException {
+}

--- a/src/test/java/seedu/address/model/meeting/DateTimeTest.java
+++ b/src/test/java/seedu/address/model/meeting/DateTimeTest.java
@@ -1,10 +1,12 @@
 package seedu.address.model.meeting;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.time.LocalDateTime;
+import java.time.Year;
 
 import org.junit.jupiter.api.Test;
 
@@ -96,5 +98,28 @@ public class DateTimeTest {
 
         // valid dates/times
         assertTrue(DateTime.isValidDuration(LocalDateTime.MIN, LocalDateTime.MAX));
+    }
+
+    @Test
+    public void getDateTime() {
+        assertEquals(new DateTime("22/02/2022").getDateTime(), "22/02/2022");
+        assertEquals(new DateTime("22-02-2022").getDateTime(), "22/02/2022");
+        assertEquals(new DateTime("22.02.2022").getDateTime(), "22/02/2022");
+        assertEquals(new DateTime("22022022").getDateTime(), "22/02/2022");
+
+        assertEquals(new DateTime("22/02/22").getDateTime(), "22/02/2022");
+        assertEquals(new DateTime("22-02-22").getDateTime(), "22/02/2022");
+        assertEquals(new DateTime("22.02.22").getDateTime(), "22/02/2022");
+        assertEquals(new DateTime("220222").getDateTime(), "22/02/2022");
+
+        assertEquals(new DateTime("22/02").getDateTime(), "22/02/" + Year.now());
+        assertEquals(new DateTime("22-02").getDateTime(), "22/02/" + Year.now());
+        assertEquals(new DateTime("22.02").getDateTime(), "22/02/" + Year.now());
+        assertEquals(new DateTime("2202").getDateTime(), "22/02/" + Year.now());
+
+        assertEquals(new DateTime("22022022 13:00").getDateTime(), "22/02/2022 13:00");
+        assertEquals(new DateTime("22022022 13.00").getDateTime(), "22/02/2022 13:00");
+        assertEquals(new DateTime("22022022 1:00AM").getDateTime(), "22/02/2022 01:00");
+        assertEquals(new DateTime("22022022 1:00PM").getDateTime(), "22/02/2022 13:00");
     }
 }

--- a/src/test/java/seedu/address/model/meeting/DateTimeTest.java
+++ b/src/test/java/seedu/address/model/meeting/DateTimeTest.java
@@ -55,18 +55,23 @@ public class DateTimeTest {
         assertFalse(DateTime.isValidDateTime("")); // empty string
         assertFalse(DateTime.isValidDateTime(" ")); // spaces only
         assertFalse(DateTime.isValidDateTime(" 22/05/2023")); // starts with a space
-        assertFalse(DateTime.isValidDateTime("22/05/2023"));
-        assertFalse(DateTime.isValidDateTime("22-05-2023"));
-        assertFalse(DateTime.isValidDateTime("22052023"));
-        assertFalse(DateTime.isValidDateTime("22-05-2023 13:22"));
-        assertFalse(DateTime.isValidDateTime("22052023 13:22"));
         assertFalse(DateTime.isValidDateTime("22/05/2023 1:32am"));
         assertFalse(DateTime.isValidDateTime("22/05/2023 1:32pm"));
+        assertFalse(DateTime.isValidDateTime("22/05/2023 1:32 AM"));
+        assertFalse(DateTime.isValidDateTime("22/05/2023 1:32 PM"));
         assertFalse(DateTime.isValidDateTime("next thursday")); // NLP
         assertFalse(DateTime.isValidDateTime("this coming friday 2:30pm")); // NLP
+        assertFalse(DateTime.isValidDateTime("22/05/2023 13:32PM"));
 
         // valid dates/times
+        assertTrue(DateTime.isValidDateTime("22052023 13:22"));
+        assertTrue(DateTime.isValidDateTime("22-05-2023 13:22"));
+        assertTrue(DateTime.isValidDateTime("22052023"));
+        assertTrue(DateTime.isValidDateTime("22-05-2023"));
+        assertTrue(DateTime.isValidDateTime("22/05/2023"));
         assertTrue(DateTime.isValidDateTime("22/05/2023 13:22"));
+        assertTrue(DateTime.isValidDateTime("22/05/2023 1:32AM"));
+        assertTrue(DateTime.isValidDateTime("22/05/2023 12:32PM"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/meeting/DateTimeTest.java
+++ b/src/test/java/seedu/address/model/meeting/DateTimeTest.java
@@ -66,9 +66,18 @@ public class DateTimeTest {
         // valid dates/times
         assertTrue(DateTime.isValidDateTime("22052023 13:22"));
         assertTrue(DateTime.isValidDateTime("22-05-2023 13:22"));
-        assertTrue(DateTime.isValidDateTime("22052023"));
-        assertTrue(DateTime.isValidDateTime("22-05-2023"));
         assertTrue(DateTime.isValidDateTime("22/05/2023"));
+        assertTrue(DateTime.isValidDateTime("22-05-2023"));
+        assertTrue(DateTime.isValidDateTime("22.05.2023"));
+        assertTrue(DateTime.isValidDateTime("22052023"));
+        assertTrue(DateTime.isValidDateTime("22/05/23"));
+        assertTrue(DateTime.isValidDateTime("22-05-23"));
+        assertTrue(DateTime.isValidDateTime("22.05.23"));
+        assertTrue(DateTime.isValidDateTime("220523"));
+        assertTrue(DateTime.isValidDateTime("2205"));
+        assertTrue(DateTime.isValidDateTime("22/05"));
+        assertTrue(DateTime.isValidDateTime("22.05"));
+        assertTrue(DateTime.isValidDateTime("22-05"));
         assertTrue(DateTime.isValidDateTime("22/05/2023 13:22"));
         assertTrue(DateTime.isValidDateTime("22/05/2023 1:32AM"));
         assertTrue(DateTime.isValidDateTime("22/05/2023 12:32PM"));

--- a/src/test/java/seedu/address/model/meeting/DateTimeTest.java
+++ b/src/test/java/seedu/address/model/meeting/DateTimeTest.java
@@ -1,7 +1,7 @@
 package seedu.address.model.meeting;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 

--- a/src/test/java/seedu/address/model/meeting/DateTimeTest.java
+++ b/src/test/java/seedu/address/model/meeting/DateTimeTest.java
@@ -122,4 +122,14 @@ public class DateTimeTest {
         assertEquals(new DateTime("22022022 1:00AM").getDateTime(), "22/02/2022 01:00");
         assertEquals(new DateTime("22022022 1:00PM").getDateTime(), "22/02/2022 13:00");
     }
+
+    @Test
+    public void get() {
+        assertEquals(new DateTime("22022022 13:00").get(),
+                LocalDateTime.of(2022, 2, 22, 13, 0));
+        assertEquals(new DateTime("22022022").get(),
+                LocalDateTime.of(2022, 2, 22, 0, 0));
+        assertEquals(new DateTime("22022022 12:00AM").get(),
+                LocalDateTime.of(2022, 2, 22, 0, 0));
+    }
 }

--- a/src/test/java/seedu/address/model/meeting/MeetingTest.java
+++ b/src/test/java/seedu/address/model/meeting/MeetingTest.java
@@ -13,6 +13,10 @@ import static seedu.address.testutil.TypicalMeetings.MEETING_A;
 import static seedu.address.testutil.TypicalMeetings.MEETING_B;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.MeetingBuilder;
@@ -88,5 +92,21 @@ public class MeetingTest {
         // different description -> returns false
         editedMeetingA = new MeetingBuilder(MEETING_A).withDescription(VALID_MEETING_DESCRIPTION).build();
         assertNotEquals(editedMeetingA, MEETING_A);
+    }
+
+    @Test
+    public void hasPassed() {
+        assertTrue(new MeetingBuilder(MEETING_A).withDateTime(
+                LocalDateTime.now().minus(1, ChronoUnit.HOURS)
+                        .format(DateTimeFormatter.ofPattern("ddMMyyyy HH:mm"))).build().hasPassed());
+        assertTrue(new MeetingBuilder(MEETING_A).withDateTime(
+                LocalDateTime.now().minus(1, ChronoUnit.MINUTES)
+                        .format(DateTimeFormatter.ofPattern("ddMMyyyy HH:mm"))).build().hasPassed());
+        assertFalse(new MeetingBuilder(MEETING_A).withDateTime(
+                LocalDateTime.now().plus(1, ChronoUnit.MINUTES)
+                        .format(DateTimeFormatter.ofPattern("ddMMyyyy HH:mm"))).build().hasPassed());
+        assertFalse(new MeetingBuilder(MEETING_A).withDateTime(
+                LocalDateTime.now().plus(1, ChronoUnit.HOURS)
+                        .format(DateTimeFormatter.ofPattern("ddMMyyyy HH:mm"))).build().hasPassed());
     }
 }


### PR DESCRIPTION
This PR implements the ability for users to input various Date/Time formats for `DateTime`. Previously, users have to stick to `dd/MM/yyyy HH:mm` else an error will be shown that the format is incorrect.

With this new implementation, users do not need to always include the time. They can leave it with just the date. Moreover, the formats for the date/time includes are now more varied and easily extensible.

### Allowed date formats:
- `dd{sep}MM{sep}yyyy`
- `dd{sep}MM{sep}yy`
- `dd{sep}MM`
- `dd{sep}MM{sep}yyyy HH{sep}mm`
- `dd{sep}MM{sep}yyyy HH{sep}mm AM`
- `dd{sep}MM{sep}yyyy HH{sep}mm PM`

where `{sep}` is a separator such as `-`, `/`, `.`