### PR TITLE
Autocomplete command words

### DIFF
--- a/src/main/java/seedu/quickcontacts/logic/commands/AutocompleteResult.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/AutocompleteResult.java
@@ -10,33 +10,55 @@ import seedu.quickcontacts.logic.parser.Prefix;
  * replace the current one.
  */
 public class AutocompleteResult {
-    private final Prefix prefix;
+    private final Optional<String> result;
     private final boolean isReplaceCurrent;
 
     /**
+     * Generates an empty {@code AutocompleteResult} that does not replace nor insert anything.
+     */
+    public AutocompleteResult() {
+        this.result = Optional.empty();
+        this.isReplaceCurrent = false;
+    }
+
+    /**
      * Generates an {@code AutocompleteResult} with the suggested {@code Prefix}
-     * and whether it should replace the current one.
+     * and whether it should replace the current one. Prefix passed cannot be null.
      *
      * @param prefix Prefix for command.
      * @param isReplaceCurrent True if suggested {@code Prefix} should replace the current, false otherwise.
      */
     public AutocompleteResult(Prefix prefix, boolean isReplaceCurrent) {
-        this.prefix = prefix;
+        assert prefix != null;
+        this.result = Optional.of(prefix.getPrefix());
         this.isReplaceCurrent = isReplaceCurrent;
     }
 
     /**
-     * Retrieves the suggested {@code Prefix}.
+     * Generates an {@code AutocompleteResult} with the suggested command word.
+     * and whether it should replace the current one. Command word string cannot be null.
      *
-     * @return Empty {@code Optional} if no {@code Prefix} is suggested, else an {@code Optional} containing the
-     *          suggested {@code Prefix}.
+     * @param commandWord Command word to be suggested.
+     * @param isReplaceCurrent True if suggested command word should replace the current, false otherwise.
      */
-    public Optional<Prefix> getPrefix() {
-        return prefix == null ? Optional.empty() : Optional.of(this.prefix);
+    public AutocompleteResult(String commandWord, boolean isReplaceCurrent) {
+        assert commandWord != null;
+        this.result = Optional.of(commandWord);
+        this.isReplaceCurrent = isReplaceCurrent;
     }
 
     /**
-     * Returns whether the autocompletion should replace the current {@code Prefix}.
+     * Retrieves the suggested result.
+     *
+     * @return Empty {@code Optional} if no result is suggested, else an {@code Optional} containing the
+     *          suggested result.
+     */
+    public Optional<String> getResult() {
+        return result;
+    }
+
+    /**
+     * Returns whether the autocompletion should replace the current prefix or command word in the user input.
      *
      * @return True if autocompletion should replace the current, false otherwise.
      */

--- a/src/main/java/seedu/quickcontacts/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/AddCommandParser.java
@@ -82,6 +82,6 @@ public class AddCommandParser implements Parser<AddCommand> {
             }
         }
 
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult();
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/AddMeetingCommandParser.java
@@ -83,6 +83,6 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
             }
         }
 
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult();
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/DeleteCommandParser.java
@@ -30,6 +30,6 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
 
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String args) {
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult();
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/parser/DeleteMeetingCommandParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/DeleteMeetingCommandParser.java
@@ -32,6 +32,6 @@ public class DeleteMeetingCommandParser implements Parser<DeleteMeetingCommand> 
 
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String args) {
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult();
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/EditCommandParser.java
@@ -83,14 +83,25 @@ public class EditCommandParser implements Parser<EditCommand> {
 
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String args) {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIXES);
+        String[] argsSplit = args.split(" ");
+        if (args.isEmpty()) {
+            return new AutocompleteResult(PREFIXES[0], false);
+        }
+        String lastPrefix = argsSplit[argsSplit.length - 1];
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(" " + lastPrefix, PREFIXES);
+        boolean returnNext = false;
 
         for (Prefix p : PREFIXES) {
-            if (argMultimap.getValue(p).isEmpty()) {
+            if (returnNext) {
                 return new AutocompleteResult(p, true);
+            }
+
+            if (argMultimap.getValue(p).isPresent() && p.toString().equals(lastPrefix)) {
+                returnNext = true;
             }
         }
 
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult(PREFIXES[0], true);
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/parser/EditMeetingParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/EditMeetingParser.java
@@ -66,7 +66,7 @@ public class EditMeetingParser implements Parser<EditMeetingsCommand> {
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String args) {
         String[] argsSplit = args.split(" ");
-        if (argsSplit.length == 0) {
+        if (args.isEmpty()) {
             return new AutocompleteResult(PREFIXES[0], false);
         }
         String lastPrefix = argsSplit[argsSplit.length - 1];

--- a/src/main/java/seedu/quickcontacts/logic/parser/ExportMeetingsParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/ExportMeetingsParser.java
@@ -60,27 +60,32 @@ public class ExportMeetingsParser implements Parser<ExportMeetingsCommand> {
 
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String input) {
-        String[] argsSplit = input.split(" ");
-        if (argsSplit.length == 0) {
+        if (input.isEmpty()) {
             return new AutocompleteResult(PREFIXES[0], false);
         }
+
+        String[] argsSplit = input.split(" ");
+        assert argsSplit.length >= 1;
+
         String lastPrefix = argsSplit[argsSplit.length - 1];
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(" " + lastPrefix, PREFIXES);
-        boolean returnNext = false;
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(input, PREFIXES);
+        ArgumentMultimap lastPrefixMap = ArgumentTokenizer.tokenize(" " + lastPrefix, PREFIXES);
+        boolean isMeetingSpecified = argumentMultimap.getValue(PREFIXES[0]).isPresent();
+        boolean isLastPrefixMeetingPrefix = lastPrefixMap.getValue(PREFIXES[0]).isPresent();
 
-        for (Prefix p : PREFIXES) {
-            if (returnNext) {
-                return new AutocompleteResult(p, true);
-            }
-
-            if (argMultimap.getValue(p).isPresent() && p.toString().equals(lastPrefix)) {
-                returnNext = true;
-            }
+        if (!isMeetingSpecified || (isLastPrefixMeetingPrefix && !lastPrefix.endsWith("/"))) {
+            return new AutocompleteResult(PREFIXES[0], false);
         }
 
-        return new AutocompleteResult(PREFIXES[0], true);
+        boolean isStartSpecified = argumentMultimap.getValue(PREFIXES[1]).isPresent();
+        boolean isEndSpecified = argumentMultimap.getValue(PREFIXES[2]).isPresent();
+        if (!isStartSpecified) {
+            return new AutocompleteResult(PREFIXES[1], true);
+        } else if (!isEndSpecified) {
+            return new AutocompleteResult(PREFIXES[2], true);
+        } else {
+            return new AutocompleteResult();
+        }
     }
-
 }
-

--- a/src/main/java/seedu/quickcontacts/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/FindCommandParser.java
@@ -33,6 +33,6 @@ public class FindCommandParser implements Parser<FindCommand> {
 
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String args) {
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult();
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/parser/FindMeetingCommandParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/FindMeetingCommandParser.java
@@ -37,6 +37,6 @@ public class FindMeetingCommandParser implements Parser<FindMeetingCommand> {
 
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String args) {
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult();
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/parser/ImportMeetingsParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/ImportMeetingsParser.java
@@ -47,6 +47,6 @@ public class ImportMeetingsParser implements Parser<ImportMeetingsCommand> {
 
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String input) {
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult();
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/parser/ImportPersonsParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/ImportPersonsParser.java
@@ -48,6 +48,6 @@ public class ImportPersonsParser implements Parser<ImportPersonsCommand> {
 
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String input) {
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult();
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/parser/QuickContactsParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/QuickContactsParser.java
@@ -39,11 +39,11 @@ public class QuickContactsParser {
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
     private static final String[] AVAILABLE_COMMAND_WORDS = {
-            AddCommand.COMMAND_WORD, EditCommand.COMMAND_WORD, DeleteCommand.COMMAND_WORD, FindCommand.COMMAND_WORD,
-            ExportPersonsCommand.COMMAND_WORD, ImportPersonsCommand.COMMAND_WORD, ListCommand.COMMAND_WORD,
-            AddMeetingCommand.COMMAND_WORD, EditMeetingsCommand.COMMAND_WORD, DeleteMeetingCommand.COMMAND_WORD,
-            ExportMeetingsCommand.COMMAND_WORD, ImportMeetingsCommand.COMMAND_WORD, ViewMeetingsCommand.COMMAND_WORD,
-            ClearCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD, HelpCommand.COMMAND_WORD};
+        AddCommand.COMMAND_WORD, EditCommand.COMMAND_WORD, DeleteCommand.COMMAND_WORD, FindCommand.COMMAND_WORD,
+        ExportPersonsCommand.COMMAND_WORD, ImportPersonsCommand.COMMAND_WORD, ListCommand.COMMAND_WORD,
+        AddMeetingCommand.COMMAND_WORD, EditMeetingsCommand.COMMAND_WORD, DeleteMeetingCommand.COMMAND_WORD,
+        ExportMeetingsCommand.COMMAND_WORD, ImportMeetingsCommand.COMMAND_WORD, ViewMeetingsCommand.COMMAND_WORD,
+        ClearCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD, HelpCommand.COMMAND_WORD};
 
     /**
      * Parses user input into command for execution.

--- a/src/main/java/seedu/quickcontacts/logic/parser/QuickContactsParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/QuickContactsParser.java
@@ -38,6 +38,13 @@ public class QuickContactsParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
+    private static final String[] AVAILABLE_COMMAND_WORDS = {
+            AddCommand.COMMAND_WORD, EditCommand.COMMAND_WORD, DeleteCommand.COMMAND_WORD, FindCommand.COMMAND_WORD,
+            ExportPersonsCommand.COMMAND_WORD, ImportPersonsCommand.COMMAND_WORD, ListCommand.COMMAND_WORD,
+            AddMeetingCommand.COMMAND_WORD, EditMeetingsCommand.COMMAND_WORD, DeleteMeetingCommand.COMMAND_WORD,
+            ExportMeetingsCommand.COMMAND_WORD, ImportMeetingsCommand.COMMAND_WORD, ViewMeetingsCommand.COMMAND_WORD,
+            ClearCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD, HelpCommand.COMMAND_WORD};
+
     /**
      * Parses user input into command for execution.
      *
@@ -122,9 +129,10 @@ public class QuickContactsParser {
      * @return the {@code AutocompleteResult} based on the user input
      */
     public AutocompleteResult getAutocompleteSuggestion(String userInput) {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        String trimmedUserInput = userInput.trim();
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(trimmedUserInput);
         if (!matcher.matches()) {
-            return new AutocompleteResult(null, false);
+            return new AutocompleteResult();
         }
 
         final String commandWord = matcher.group("commandWord");
@@ -143,12 +151,21 @@ public class QuickContactsParser {
 
         case EditMeetingsCommand.COMMAND_WORD:
             return new EditMeetingParser().getAutocompleteSuggestion(arguments);
+
         case ExportPersonsCommand.COMMAND_WORD:
             return new ExportPersonsParser().getAutocompleteSuggestion(arguments);
+
         case ExportMeetingsCommand.COMMAND_WORD:
             return new ExportMeetingsParser().getAutocompleteSuggestion(arguments);
+
         default:
-            return new AutocompleteResult(null, false);
+            for (String word : AVAILABLE_COMMAND_WORDS) {
+                if (word.startsWith(commandWord)) {
+                    return new AutocompleteResult(word, true);
+                }
+            }
+
+            return new AutocompleteResult();
         }
     }
 

--- a/src/main/java/seedu/quickcontacts/logic/parser/SortMeetingParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/SortMeetingParser.java
@@ -30,7 +30,7 @@ public class SortMeetingParser implements Parser<SortMeetingCommand> {
 
     @Override
     public AutocompleteResult getAutocompleteSuggestion(String args) {
-        return new AutocompleteResult(null, false);
+        return new AutocompleteResult();
     }
 
     @Override

--- a/src/main/java/seedu/quickcontacts/ui/CommandBox.java
+++ b/src/main/java/seedu/quickcontacts/ui/CommandBox.java
@@ -142,24 +142,30 @@ public class CommandBox extends UiPart<Region> {
                     AutocompleteResult suggestion = commandInputSuggester.suggest(commandTextField.getText());
                     String currInput = commandTextField.getText().trim();
 
-                    if (suggestion.getPrefix().isEmpty()) {
+                    if (suggestion.getResult().isEmpty()) {
                         break;
                     }
 
-                    String prefix = suggestion.getPrefix().get().getPrefix();
+                    String result = suggestion.getResult().get();
 
                     if (!suggestion.isReplaceCurrent()) {
-                        commandTextField.setText(currInput + " " + prefix);
+                        commandTextField.setText(currInput + " " + result);
                         break;
                     }
 
                     // Replaces current prefix
                     String[] currInputSplit = currInput.split(" ");
-                    if (currInputSplit[currInputSplit.length - 1].endsWith("/")) {
-                        currInputSplit[currInputSplit.length - 1] = prefix;
+                    boolean isEmptyParameter = currInputSplit[currInputSplit.length - 1].endsWith("/");
+                    if (isEmptyParameter) {
+                        // Replace last prefix with the new suggestion result
+                        currInputSplit[currInputSplit.length - 1] = result;
                         commandTextField.setText(String.join(" ", currInputSplit));
+                    } else if (currInputSplit.length == 1) {
+                        // Replace command word
+                        commandTextField.setText(result);
                     } else {
-                        commandTextField.setText(currInput + " " + prefix);
+                        // Append suggestion
+                        commandTextField.setText(currInput + " " + result);
                     }
                 } finally {
                     event.consume();

--- a/src/test/java/seedu/quickcontacts/logic/commands/AutocompleteResultTest.java
+++ b/src/test/java/seedu/quickcontacts/logic/commands/AutocompleteResultTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import seedu.quickcontacts.logic.parser.Prefix;
@@ -15,13 +14,16 @@ public class AutocompleteResultTest {
     @Test
     public void getPrefix() {
         Prefix prefix = new Prefix("m/");
-        Assertions.assertEquals(new AutocompleteResult(prefix, false).getPrefix(), Optional.of(prefix));
-        assertEquals(new AutocompleteResult(null, false).getPrefix(), Optional.empty());
+        assertEquals(new AutocompleteResult(prefix, false).getResult(), Optional.of(prefix.getPrefix()));
+        assertEquals(new AutocompleteResult().getResult(), Optional.empty());
     }
 
     @Test
     public void isReplaceCurrent() {
-        assertTrue(new AutocompleteResult(null, true).isReplaceCurrent());
-        assertFalse(new AutocompleteResult(new Prefix("m/"), false).isReplaceCurrent());
+        assertFalse(new AutocompleteResult().isReplaceCurrent());
+
+        Prefix prefix = new Prefix("m/");
+        assertFalse(new AutocompleteResult(prefix, false).isReplaceCurrent());
+        assertTrue(new AutocompleteResult(prefix, true).isReplaceCurrent());
     }
 }


### PR DESCRIPTION
This PR implements the enhancement to autocompletion to be done for command words in addition to just prefixes.

For example, upon pressing `TAB` on `a` as the input, it will be autocompleted to `add`. Users can then press `TAB` again and it will autocomplete the prefix, which in this case would become `add n/`

closes #125 