### PR TITLE
Update Help Command

### DIFF
--- a/src/main/java/seedu/quickcontacts/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/AddCommand.java
@@ -18,10 +18,9 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
-            + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + PREFIX_PHONE + "PHONE "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. \n"
+            + "Required Parameters: " + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE \n"
+            + "Optional Parameters: "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"

--- a/src/main/java/seedu/quickcontacts/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/AddCommand.java
@@ -17,6 +17,7 @@ import seedu.quickcontacts.model.person.Person;
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_DESCRIPTION = "Adds the contact of a person to the address book.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. \n"
             + "Required Parameters: " + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE \n"

--- a/src/main/java/seedu/quickcontacts/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/AddMeetingCommand.java
@@ -48,6 +48,7 @@ public class AddMeetingCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
 
     public static final String MESSAGE_DUPLICATE_MEETING = "This meeting already exists in the address book";
+    public static final String COMMAND_DESCRIPTION = "Adds a meeting to the address book.";
 
     private final Title meetingTitle;
     private final DateTime dateTime;

--- a/src/main/java/seedu/quickcontacts/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/AddMeetingCommand.java
@@ -31,10 +31,11 @@ import seedu.quickcontacts.model.person.Person;
 public class AddMeetingCommand extends Command {
     public static final String COMMAND_WORD = "addm";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a meeting to the address book. "
-        + "Parameters: "
-        + PREFIX_MEETING_TITLE + "MEETING "
+        + "Required Parameters: "
+        + PREFIX_MEETING_TITLE + "MEETING_TITLE "
+        + PREFIX_DATETIME + DATE_FORMAT + " " + TIME_FORMAT + "\n"
+        + "Optional Parameters: "
         + PREFIX_PERSON + "NAME "
-        + PREFIX_DATETIME + DATE_FORMAT + " " + TIME_FORMAT + " "
         + PREFIX_LOCATION + "LOCATION "
         + PREFIX_DESCRIPTION + "DESCRIPTION\n"
         + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/quickcontacts/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ClearCommand.java
@@ -12,6 +12,8 @@ public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Clears all contacts and meetings from the address book.\n" + "Example: " + COMMAND_WORD;
 
 
     @Override

--- a/src/main/java/seedu/quickcontacts/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ClearCommand.java
@@ -14,6 +14,7 @@ public class ClearCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Clears all contacts and meetings from the address book.\n" + "Example: " + COMMAND_WORD;
+    public static final String COMMAND_DESCRIPTION = "Clears all contacts and meetings from the address book.";
 
 
     @Override

--- a/src/main/java/seedu/quickcontacts/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/DeleteCommand.java
@@ -23,6 +23,7 @@ public class DeleteCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String COMMAND_DESCRIPTION = "Delete a contact.";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/quickcontacts/logic/commands/DeleteMeetingCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/DeleteMeetingCommand.java
@@ -19,6 +19,7 @@ public class DeleteMeetingCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
     public static final String MESSAGE_SUCCESS = "Meeting Deleted: %1$s";
+    public static final String COMMAND_DESCRIPTION = "Deletes a meeting from the address book.";
 
     private final Index index;
 

--- a/src/main/java/seedu/quickcontacts/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/EditCommand.java
@@ -49,6 +49,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String COMMAND_DESCRIPTION = "Edit a contact.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/quickcontacts/logic/commands/EditMeetingsCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/EditMeetingsCommand.java
@@ -49,6 +49,7 @@ public class EditMeetingsCommand extends Command {
     public static final String MESSAGE_EDIT_MEETING_SUCCESS = "Edited Meeting: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_MEETING = "This meeting already exists in the address book.";
+    public static final String COMMAND_DESCRIPTION = "Edits the details of the meeting identified.";
 
     private final Index index;
     private final EditMeetingDescriptor editMeetingDescriptor;

--- a/src/main/java/seedu/quickcontacts/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ExitCommand.java
@@ -11,6 +11,7 @@ public class ExitCommand extends Command {
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits the program.\n" + "Example: " + COMMAND_WORD;
+    public static final String COMMAND_DESCRIPTION = "Exits the program.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/quickcontacts/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ExitCommand.java
@@ -10,6 +10,7 @@ public class ExitCommand extends Command {
     public static final String COMMAND_WORD = "exit";
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits the program.\n" + "Example: " + COMMAND_WORD;
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/quickcontacts/logic/commands/ExportMeetingsCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ExportMeetingsCommand.java
@@ -22,6 +22,7 @@ public class ExportMeetingsCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exports meetings in JSON format\n" + "Parameters: m/ "
             + "index of meeting start/: optional starting point of range end/: optional ending point of range";
     public static final String INDEX_NOT_FOUND = "One of the provided indices is not found";
+    public static final String COMMAND_DESCRIPTION = "Exports meetings in JSON format.";
 
     private final List<Index> indexList;
 

--- a/src/main/java/seedu/quickcontacts/logic/commands/ExportPersonsCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ExportPersonsCommand.java
@@ -21,6 +21,7 @@ public class ExportPersonsCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exports persons in JSON format\n" + "Parameters: p/ "
             + "index of person";
     public static final String INDEX_NOT_FOUND = "One of the provided indices is not found";
+    public static final String COMMAND_DESCRIPTION = "Exports persons in JSON format.";
 
     private final List<Index> indexList;
 

--- a/src/main/java/seedu/quickcontacts/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/FindCommand.java
@@ -18,6 +18,8 @@ public class FindCommand extends Command {
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String COMMAND_DESCRIPTION = "Finds all persons whose names contain any of "
+            + "the specified keywords (case-insensitive).";
 
     private final NameContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/quickcontacts/logic/commands/FindMeetingCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/FindMeetingCommand.java
@@ -19,6 +19,8 @@ public class FindMeetingCommand extends Command {
         + "Example: " + COMMAND_WORD + " alice bob charlie\n"
         + "or"
         + "Example: " + COMMAND_WORD;
+    public static final String COMMAND_DESCRIPTION = "Finds all meetings whose attendees contain any of "
+        + "the specified person names (case-insensitive).";
     private final MeetingContainsNamesPredicate predicate;
 
     public FindMeetingCommand(MeetingContainsNamesPredicate predicate) {

--- a/src/main/java/seedu/quickcontacts/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/HelpCommand.java
@@ -10,11 +10,32 @@ public class HelpCommand extends Command {
     public static final String COMMAND_WORD = "help";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
-            + "Example: " + COMMAND_WORD;
+        + "Example: " + COMMAND_WORD;
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 
-    private static final String COMMAND_DOES_NOT_EXIST = "Command does not exist";
+    private static final String COMMAND_DOES_NOT_EXIST = "This command does not exist in Quick Contacts.";
+    private static final String COMMAND_DESCRIPTION = "Shows program usage instructions.";
+    private static final String LIST_OF_AVAILABLE_COMMANDS = "Here are the list of available commands:\n"
+        + "Enter `help [command]` to find out more about each command.\n"
+        + "1. " + AddCommand.COMMAND_WORD + ": " + AddCommand.COMMAND_DESCRIPTION + "\n"
+        + "2. " + EditCommand.COMMAND_WORD + ": " + EditCommand.COMMAND_DESCRIPTION + "\n"
+        + "3. " + DeleteCommand.COMMAND_WORD + ": " + DeleteCommand.COMMAND_DESCRIPTION + "\n"
+        + "4. " + ClearCommand.COMMAND_WORD + ": " + ClearCommand.COMMAND_DESCRIPTION + "\n"
+        + "5. " + FindCommand.COMMAND_WORD + ": " + FindCommand.COMMAND_DESCRIPTION + "\n"
+        + "6. " + ListCommand.COMMAND_WORD + ": " + ListCommand.COMMAND_DESCRIPTION + "\n"
+        + "7. " + ExportPersonsCommand.COMMAND_WORD + ": " + ExportPersonsCommand.COMMAND_DESCRIPTION + "\n"
+        + "8. " + ImportPersonsCommand.COMMAND_WORD + ": " + ImportPersonsCommand.COMMAND_DESCRIPTION + "\n"
+        + "9. " + AddMeetingCommand.COMMAND_WORD + ": " + AddMeetingCommand.COMMAND_DESCRIPTION + "\n"
+        + "10. " + FindMeetingCommand.COMMAND_WORD + ": " + FindMeetingCommand.COMMAND_DESCRIPTION + "\n"
+        + "11. " + ViewMeetingsCommand.COMMAND_WORD + ": " + ViewMeetingsCommand.COMMAND_DESCRIPTION + "\n"
+        + "12. " + EditMeetingsCommand.COMMAND_WORD + ": " + EditMeetingsCommand.COMMAND_DESCRIPTION + "\n"
+        + "13. " + DeleteMeetingCommand.COMMAND_WORD + ": " + DeleteMeetingCommand.COMMAND_DESCRIPTION + "\n"
+        + "14. " + ExportMeetingsCommand.COMMAND_WORD + ": " + ExportMeetingsCommand.COMMAND_DESCRIPTION + "\n"
+        + "15. " + ImportMeetingsCommand.COMMAND_WORD + ": " + ImportMeetingsCommand.COMMAND_DESCRIPTION + "\n"
+        + "16. " + SortMeetingCommand.COMMAND_WORD + ": " + SortMeetingCommand.COMMAND_DESCRIPTION + "\n"
+        + "17. " + HelpCommand.COMMAND_WORD + ": " + HelpCommand.COMMAND_DESCRIPTION + "\n"
+        + "18. " + ExitCommand.COMMAND_WORD + ": " + ExitCommand.COMMAND_DESCRIPTION + "\n";
     private static final String SHOW_HELP_POPUP = "";
     private final String commandWord;
 
@@ -88,13 +109,14 @@ public class HelpCommand extends Command {
             return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
 
         default:
-            return new CommandResult(COMMAND_DOES_NOT_EXIST);
+            return new CommandResult(COMMAND_DOES_NOT_EXIST + "\n\n" + LIST_OF_AVAILABLE_COMMANDS);
         }
     }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof HelpCommand // instanceof handles nulls
-                && commandWord.equals(((HelpCommand) other).commandWord)); // state check
+            || (other instanceof HelpCommand // instanceof handles nulls
+            && commandWord.equals(((HelpCommand) other).commandWord)); // state check
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/HelpCommand.java
@@ -14,8 +14,87 @@ public class HelpCommand extends Command {
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 
+    private static final String COMMAND_DOES_NOT_EXIST = "Command does not exist";
+    private static final String SHOW_HELP_POPUP = "";
+    private final String commandWord;
+
+    public HelpCommand() {
+        this.commandWord = SHOW_HELP_POPUP;
+    }
+
+    public HelpCommand(String commandWord) {
+        this.commandWord = commandWord;
+    }
+
+
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        switch (commandWord) {
+        case AddCommand.COMMAND_WORD:
+            return new CommandResult(AddCommand.MESSAGE_USAGE);
+
+        case EditCommand.COMMAND_WORD:
+            return new CommandResult(EditCommand.MESSAGE_USAGE);
+
+        case DeleteCommand.COMMAND_WORD:
+            return new CommandResult(DeleteCommand.MESSAGE_USAGE);
+
+        case ClearCommand.COMMAND_WORD:
+            return new CommandResult(ClearCommand.MESSAGE_USAGE);
+
+        case FindCommand.COMMAND_WORD:
+            return new CommandResult(FindCommand.MESSAGE_USAGE);
+
+        case ListCommand.COMMAND_WORD:
+            return new CommandResult(ListCommand.MESSAGE_USAGE);
+
+        case ExitCommand.COMMAND_WORD:
+            return new CommandResult(ExitCommand.MESSAGE_USAGE);
+
+        case HelpCommand.COMMAND_WORD:
+            return new CommandResult(HelpCommand.MESSAGE_USAGE);
+
+        case AddMeetingCommand.COMMAND_WORD:
+            return new CommandResult(AddMeetingCommand.MESSAGE_USAGE);
+
+        case FindMeetingCommand.COMMAND_WORD:
+            return new CommandResult(FindMeetingCommand.MESSAGE_USAGE);
+
+        case ViewMeetingsCommand.COMMAND_WORD:
+            return new CommandResult(ViewMeetingsCommand.MESSAGE_USAGE);
+
+        case EditMeetingsCommand.COMMAND_WORD:
+            return new CommandResult(EditMeetingsCommand.MESSAGE_USAGE);
+
+        case DeleteMeetingCommand.COMMAND_WORD:
+            return new CommandResult(DeleteMeetingCommand.MESSAGE_USAGE);
+
+        case ExportPersonsCommand.COMMAND_WORD:
+            return new CommandResult(ExportPersonsCommand.MESSAGE_USAGE);
+
+        case ImportPersonsCommand.COMMAND_WORD:
+            return new CommandResult(ImportPersonsCommand.MESSAGE_USAGE);
+
+        case SortMeetingCommand.COMMAND_WORD:
+            return new CommandResult(SortMeetingCommand.MESSAGE_USAGE);
+
+        case ExportMeetingsCommand.COMMAND_WORD:
+            return new CommandResult(ExportMeetingsCommand.MESSAGE_USAGE);
+
+        case ImportMeetingsCommand.COMMAND_WORD:
+            return new CommandResult(ImportMeetingsCommand.MESSAGE_USAGE);
+
+        case SHOW_HELP_POPUP:
+            return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+
+        default:
+            return new CommandResult(COMMAND_DOES_NOT_EXIST);
+        }
+    }
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof HelpCommand // instanceof handles nulls
+                && commandWord.equals(((HelpCommand) other).commandWord)); // state check
     }
 }

--- a/src/main/java/seedu/quickcontacts/logic/commands/ImportMeetingsCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ImportMeetingsCommand.java
@@ -14,6 +14,7 @@ import seedu.quickcontacts.model.meeting.exceptions.DuplicateMeetingException;
  */
 public class ImportMeetingsCommand extends Command {
     public static final String COMMAND_WORD = "importm";
+    public static final String COMMAND_DESCRIPTION = "Imports meetings in JSON format.";
     static final String DUPLICATE_MEETING = "Duplicate meeting found";
     static final String SUCCESS = "Meetings imported";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports meetings in JSON format\n" + "Parameters: "

--- a/src/main/java/seedu/quickcontacts/logic/commands/ImportPersonsCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ImportPersonsCommand.java
@@ -14,6 +14,7 @@ import seedu.quickcontacts.model.person.exceptions.DuplicatePersonException;
  */
 public class ImportPersonsCommand extends Command {
     public static final String COMMAND_WORD = "import";
+    public static final String COMMAND_DESCRIPTION = "Imports persons in JSON format.";
     static final String DUPLICATE_PERSON = "Duplicate person found";
     static final String SUCCESS = "Persons imported";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports persons in JSON format\n" + "Parameters: "

--- a/src/main/java/seedu/quickcontacts/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ListCommand.java
@@ -13,6 +13,8 @@ public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Lists all persons in the address book.\n" + "Example: " + COMMAND_WORD;
 
 
     @Override

--- a/src/main/java/seedu/quickcontacts/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ListCommand.java
@@ -15,6 +15,7 @@ public class ListCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Listed all persons";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Lists all persons in the address book.\n" + "Example: " + COMMAND_WORD;
+    public static final String COMMAND_DESCRIPTION = "Lists all persons in the address book.";
 
 
     @Override

--- a/src/main/java/seedu/quickcontacts/logic/commands/SortMeetingCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/SortMeetingCommand.java
@@ -21,6 +21,7 @@ public class SortMeetingCommand extends Command {
             + "Example: `sortm m/`.i \n"
             + "For reverse sorting, append an `r` after the prefix.\n"
             + "Example: `sortm m/r`";
+    public static final String COMMAND_DESCRIPTION = "Sorts meetings by their attributes.";
     private static Prefix sortByPrefix;
     private static String prefix;
     private static boolean isReverse;

--- a/src/main/java/seedu/quickcontacts/logic/commands/ViewMeetingsCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ViewMeetingsCommand.java
@@ -13,6 +13,7 @@ public class ViewMeetingsCommand extends Command {
     public static final String COMMAND_WORD = "listm";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all meetings in the address book.\n"
             + "Example: " + COMMAND_WORD;
+    public static final String COMMAND_DESCRIPTION = "Lists all meetings in the address book.";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/quickcontacts/logic/commands/ViewMeetingsCommand.java
+++ b/src/main/java/seedu/quickcontacts/logic/commands/ViewMeetingsCommand.java
@@ -11,6 +11,8 @@ import seedu.quickcontacts.model.meeting.Meeting;
  */
 public class ViewMeetingsCommand extends Command {
     public static final String COMMAND_WORD = "listm";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all meetings in the address book.\n"
+            + "Example: " + COMMAND_WORD;
 
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/quickcontacts/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/HelpCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.quickcontacts.logic.parser;
+import static java.util.Objects.requireNonNull;
+import static seedu.quickcontacts.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.quickcontacts.logic.commands.AutocompleteResult;
+import seedu.quickcontacts.logic.commands.HelpCommand;
+import seedu.quickcontacts.logic.parser.exceptions.ParseException;
+
+
+/**
+ * Parses input arguments and creates a new HelpCommand object.
+ */
+public class HelpCommandParser implements Parser<HelpCommand> {
+    @Override
+    public HelpCommand parse(String userInput) throws ParseException {
+        requireNonNull(userInput);
+        if (userInput.isEmpty()) {
+            return new HelpCommand();
+        }
+        String trimmedArgs = userInput.trim();
+        if (trimmedArgs.split("\\s+").length != 1) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+        return new HelpCommand(trimmedArgs);
+    }
+
+    @Override
+    public AutocompleteResult getAutocompleteSuggestion(String input) {
+        return new AutocompleteResult(null, false);
+    }
+}

--- a/src/main/java/seedu/quickcontacts/logic/parser/QuickContactsParser.java
+++ b/src/main/java/seedu/quickcontacts/logic/parser/QuickContactsParser.java
@@ -78,7 +78,7 @@ public class QuickContactsParser {
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            return new HelpCommandParser().parse(arguments);
 
         case AddMeetingCommand.COMMAND_WORD:
             return new AddMeetingCommandParser().parse(arguments);

--- a/src/main/java/seedu/quickcontacts/ui/HelpWindow.java
+++ b/src/main/java/seedu/quickcontacts/ui/HelpWindow.java
@@ -16,19 +16,15 @@ import seedu.quickcontacts.commons.core.LogsCenter;
 public class HelpWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
-    public static final String HELP_MESSAGE = "The following are required prefix for addm"
-            + " and add command and what they stand for. \n"
+    public static final String HELP_MESSAGE = "The following are summary of prefixes and what they represent. \n"
             + "You can press the tab key to fill in the next parameter, \n"
-            + "if you forget what comes next. The other commands use the \n"
-            + "same prefixes to refer to a meeting/person property\n"
-            + "addm: \n"
-            + "Prefix: m/ dt/ p/ l/ des/\n"
+            + "if you forget what comes next."
+            + "Meeting Related Prefix: m/ dt/ p/ l/ des/\n"
             + "m/ : meeting title\n"
             + "dt/ : datetime\n"
             + "p/ : person attending the meeting (use this tag for each person attending)\n"
             + "des/ : description of the meeting\n\n"
-            + "add: \n"
-            + "Prefix required: n/ p/ e/ a/ t/\n"
+            + "Contact Related Prefix: n/ p/ e/ a/ t/\n"
             + "n/: name\n"
             + "p/: phone number\n"
             + "e/: email\n"

--- a/src/main/java/seedu/quickcontacts/ui/HelpWindow.java
+++ b/src/main/java/seedu/quickcontacts/ui/HelpWindow.java
@@ -17,12 +17,13 @@ public class HelpWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
     public static final String HELP_MESSAGE = "The following are summary of prefixes and what they represent. \n"
-            + "You can press the tab key to fill in the next parameter, \n"
-            + "if you forget what comes next."
+            + "You can press the tab key to fill in the next parameter, "
+            + "if you forget what comes next.\n\n"
             + "Meeting Related Prefix: m/ dt/ p/ l/ des/\n"
             + "m/ : meeting title\n"
             + "dt/ : datetime\n"
             + "p/ : person attending the meeting (use this tag for each person attending)\n"
+            + "l/ : location of the meeting\n"
             + "des/ : description of the meeting\n\n"
             + "Contact Related Prefix: n/ p/ e/ a/ t/\n"
             + "n/: name\n"

--- a/src/test/java/seedu/quickcontacts/logic/parser/QuickContactsParserTest.java
+++ b/src/test/java/seedu/quickcontacts/logic/parser/QuickContactsParserTest.java
@@ -88,6 +88,9 @@ public class QuickContactsParserTest {
 
     @Test
     public void parseCommand_help() throws Exception {
+        HelpCommand command = (HelpCommand) parser.parseCommand(HelpCommand.COMMAND_WORD
+                + " " + AddCommand.COMMAND_WORD);
+        assertEquals(new HelpCommand(AddCommand.COMMAND_WORD), command);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }


### PR DESCRIPTION
Closes #129 

## Changes
### Added
- `HelpCommandParser` now that `help` command can be used with arguments 7da4b1a83d1cb38539ab3fc87201e27fa53e7638
- `COMMAND_DESCRIPTION` to each command that is a brief description of the command's function, a more succinct form of `MESSAGE_USAGE`  401e4968b5006454df12678a5512221fbd656ba1 56e2cb3e537a4f919637d919326b9628c8120396

### Updated
- Add `MESSAGE_USAGE` to commands that previously lacked them aaa7bf19e11b4197132fb183d50d3b296508b130 2fac86c08235586f41cdd2112b0603ccc14214b8
- Update `MESSAGE_USAGE` in `AddCommand` and `AddMeetingCommand` to reflect changes in their commands in my previous PR 9dea288d6f82933fbd19a2e1c166d899537dbbe2
- Change `HelpCommand` to return appropriate `CommandResult` based on requested help message 7da4b1a83d1cb38539ab3fc87201e27fa53e7638
- Updated `QuickContactsParser` test case to reflect changes to `HelpCommand` 4cabeaf913d9c9c3d1ff47843f54ea7f766512d7

### Help Command Usage
```
// Causes popup to come with link to User Guide
help

// Displays help message for the relevant command in the output box
// Only accepts one command word, if more are provided will show error
help [command_word]
```

### To be done
- Test cases for `HelpCommandParser`
- More test cases for the new behaviour of `HelpCommand`