### PR TITLE
Add wrapping of text for UI elements

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -291,7 +291,7 @@ Format: `help`
 ### Adding a person: `add`
 <div markdown="block" class="alert alert-warning">
 
-**:warning: Tags**<br>
+**:warning: Caution**<br>
 Tags of length more than 10 are unsupported! UI artifacts may occur.
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -289,6 +289,11 @@ Format: `help`
 
 
 ### Adding a person: `add`
+<div markdown="block" class="alert alert-warning">
+
+**:warning: Tags**<br>
+Tags of length more than 10 are unsupported! UI artifacts may occur.
+</div>
 
 Adds a person to the address book.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -292,7 +292,7 @@ Format: `help`
 <div markdown="block" class="alert alert-warning">
 
 **:warning: Caution**<br>
-Tags of length more than 10 are unsupported! UI artifacts may occur.
+Tags of more than 10 characters are unsupported! UI artifacts may occur.
 </div>
 
 Adds a person to the address book.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -293,6 +293,7 @@ Format: `help`
 
 **:warning: Caution**<br>
 Tags of more than 10 characters are unsupported! UI artifacts may occur.
+
 </div>
 
 Adds a person to the address book.

--- a/src/main/resources/view/MeetingListCard.fxml
+++ b/src/main/resources/view/MeetingListCard.fxml
@@ -24,10 +24,10 @@
                         <Region fx:constant="USE_PREF_SIZE"/>
                     </minWidth>
                 </Label>
-                <Label fx:id="title" styleClass="cell_big_label"/>
+                <Label fx:id="title" styleClass="cell_big_label" wrapText="true"/>
             </HBox>
             <Label fx:id="dateTime" styleClass="cell_small_label"/>
-            <Label fx:id="description" styleClass="cell_small_label"/>
+            <Label fx:id="description" styleClass="cell_small_label" wrapText="true"/>
             <Label fx:id="attendees" styleClass="cell_small_label"/>
             <Label fx:id="meetingLocation" styleClass="cell_small_label" wrapText="true"/>
         </VBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -25,12 +25,12 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true"/>
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" />
-      <Label fx:id="address" styleClass="cell_small_label" />
-      <Label fx:id="email" styleClass="cell_small_label" />
+      <Label fx:id="address" styleClass="cell_small_label" wrapText="true" />
+      <Label fx:id="email" styleClass="cell_small_label" wrapText="true"/>
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
Fixes #159 and #132

- Add warning that tags of length >10 are not supported
- Add wrapping for text elements