### PR TITLE
Fix invalid date being accepted

### DIFF
--- a/src/main/java/seedu/quickcontacts/model/meeting/DateTime.java
+++ b/src/main/java/seedu/quickcontacts/model/meeting/DateTime.java
@@ -11,6 +11,7 @@ import java.time.LocalTime;
 import java.time.Year;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -48,9 +49,9 @@ public class DateTime implements Comparable<DateTime> {
     private static final String[] TIME_SEPARATORS = {":", "", "."};
     private static final String SEPARATOR_PLACEHOLDER = "{sep}";
     private static final String DDMMYYYY_TEMPLATE = "dd" + SEPARATOR_PLACEHOLDER + "MM"
-            + SEPARATOR_PLACEHOLDER + "yyyy";
+            + SEPARATOR_PLACEHOLDER + "uuuu";
     private static final String DDMMYY_TEMPLATE = "dd" + SEPARATOR_PLACEHOLDER + "MM"
-            + SEPARATOR_PLACEHOLDER + "yy";
+            + SEPARATOR_PLACEHOLDER + "uu";
     private static final String DDMM_TEMPLATE = "dd" + SEPARATOR_PLACEHOLDER + "MM";
     private static final String HHMM_TEMPLATE = "HH" + SEPARATOR_PLACEHOLDER + "mm";
     private static final String HHMM_AM_PM_TEMPLATE = "h" + SEPARATOR_PLACEHOLDER + "mma";
@@ -197,7 +198,8 @@ public class DateTime implements Comparable<DateTime> {
     private static LocalDate parseDate(String date, String pattern) {
         try {
             if (!pattern.equals("ddMM")) {
-                return LocalDate.parse(date, DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH));
+                return LocalDate.parse(date,
+                        DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH).withResolverStyle(ResolverStyle.STRICT));
             }
 
             if (date.length() != 4 && date.length() != 5) {
@@ -209,7 +211,9 @@ public class DateTime implements Comparable<DateTime> {
                 newDate = date + date.charAt(2) + Year.now();
             }
 
-            return LocalDate.parse(newDate, DateTimeFormatter.ofPattern(getDateFormat(newDate), Locale.ENGLISH));
+            return LocalDate.parse(newDate,
+                    DateTimeFormatter.ofPattern(getDateFormat(newDate), Locale.ENGLISH)
+                        .withResolverStyle(ResolverStyle.STRICT));
         } catch (DateTimeParseException | InvalidDateTimeFormatException e) {
             return LocalDate.MAX;
         }

--- a/src/test/java/seedu/quickcontacts/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/quickcontacts/logic/parser/ParserUtilTest.java
@@ -39,7 +39,7 @@ public class ParserUtilTest {
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_NAME_2 = "Jack Walker";
     private static final String VALID_TITLE = "Meeting 1";
-    private static final String VALID_DATETIME = "29/02/2023 12:00";
+    private static final String VALID_DATETIME = "28/02/2023 12:00";
     private static final String VALID_LOCATION = "Singapore NUS";
     private static final String VALID_DESCRIPTION = "Meeting with Jack";
     private static final String VALID_PHONE = "123456";

--- a/src/test/java/seedu/quickcontacts/model/meeting/DateTimeTest.java
+++ b/src/test/java/seedu/quickcontacts/model/meeting/DateTimeTest.java
@@ -64,6 +64,9 @@ public class DateTimeTest {
         assertFalse(DateTime.isValidDateTime("next thursday")); // NLP
         assertFalse(DateTime.isValidDateTime("this coming friday 2:30pm")); // NLP
         assertFalse(DateTime.isValidDateTime("22/05/2023 13:32PM"));
+        assertFalse(DateTime.isValidDateTime("29/02/2023")); // none leap year
+        assertFalse(DateTime.isValidDateTime("31/04/2023")); // April only has 30 days
+        assertFalse(DateTime.isValidDateTime("32/01/2023")); // Out of bounds date
 
         // valid dates/times
         assertTrue(DateTime.isValidDateTime("22052023 13:22"));
@@ -83,6 +86,9 @@ public class DateTimeTest {
         assertTrue(DateTime.isValidDateTime("22/05/2023 13:22"));
         assertTrue(DateTime.isValidDateTime("22/05/2023 1:32AM"));
         assertTrue(DateTime.isValidDateTime("22/05/2023 12:32PM"));
+        assertTrue(DateTime.isValidDateTime("28/02/2023")); // all februarys have 28 days
+        assertTrue(DateTime.isValidDateTime("01/01/2023")); // first day of a month
+        assertTrue(DateTime.isValidDateTime("31/01/2023")); // last day of a month
     }
 
     @Test

--- a/src/test/java/seedu/quickcontacts/model/meeting/DateTimeTest.java
+++ b/src/test/java/seedu/quickcontacts/model/meeting/DateTimeTest.java
@@ -89,6 +89,7 @@ public class DateTimeTest {
         assertTrue(DateTime.isValidDateTime("28/02/2023")); // all februarys have 28 days
         assertTrue(DateTime.isValidDateTime("01/01/2023")); // first day of a month
         assertTrue(DateTime.isValidDateTime("31/01/2023")); // last day of a month
+        assertTrue(DateTime.isValidDateTime("29/02/2020")); // leap year extra day True
     }
 
     @Test


### PR DESCRIPTION
This PR fixes #164.

Previously, QuickContacts will still go ahead and create a meeting with an invalid date, for example `31/02/2023` by automatically changing it to `28/02/2023`. Similarly, for dates like `31/04/2023` will be automatically changed to the last valid date of that month, in this case, `30/04/2023`.

This PR fixes that by having a `strict` check for the dates.